### PR TITLE
Translate Blood Chest messaging to English

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>enginehub-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -62,6 +66,18 @@
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.2.15</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
+            <version>7.2.15</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/pl/yourserver/bloodChestPlugin/BloodChestPlugin.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/BloodChestPlugin.java
@@ -1,17 +1,82 @@
 package pl.yourserver.bloodChestPlugin;
 
+import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
+import pl.yourserver.bloodChestPlugin.command.BloodChestCommand;
+import pl.yourserver.bloodChestPlugin.config.ConfigurationLoader;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.gui.MenuManager;
+import pl.yourserver.bloodChestPlugin.integration.IngredientPouchBridge;
+import pl.yourserver.bloodChestPlugin.loot.LootLoader;
+import pl.yourserver.bloodChestPlugin.loot.LootRegistry;
+import pl.yourserver.bloodChestPlugin.loot.LootService;
+import pl.yourserver.bloodChestPlugin.session.PityManager;
+import pl.yourserver.bloodChestPlugin.session.SessionListener;
+import pl.yourserver.bloodChestPlugin.session.SessionManager;
+import pl.yourserver.bloodChestPlugin.session.WorldEditSchematicHandler;
+
+import java.io.File;
 
 public final class BloodChestPlugin extends JavaPlugin {
 
+    private PluginConfiguration configuration;
+    private LootRegistry lootRegistry;
+    private LootService lootService;
+    private PityManager pityManager;
+    private SessionManager sessionManager;
+    private MenuManager menuManager;
+    private IngredientPouchBridge pouchBridge;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        saveResourceIfMissing("items.yml");
 
+        try {
+            ConfigurationLoader configurationLoader = new ConfigurationLoader();
+            configuration = configurationLoader.load(getConfig());
+
+            File itemsFile = new File(getDataFolder(), "items.yml");
+            LootLoader lootLoader = new LootLoader();
+            lootRegistry = lootLoader.load(itemsFile);
+
+            pityManager = new PityManager(this);
+            lootService = new LootService(lootRegistry, configuration.getPitySettings());
+            sessionManager = new SessionManager(this, configuration, new WorldEditSchematicHandler(), lootService, pityManager);
+            pouchBridge = new IngredientPouchBridge(getLogger());
+            menuManager = new MenuManager(this, configuration, sessionManager, lootRegistry, pouchBridge);
+        } catch (Exception ex) {
+            getLogger().severe("Failed to load BloodChestPlugin configuration: " + ex.getMessage());
+            ex.printStackTrace();
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        getServer().getPluginManager().registerEvents(menuManager, this);
+        getServer().getPluginManager().registerEvents(new SessionListener(sessionManager), this);
+
+        PluginCommand command = getCommand("blood_chest");
+        if (command != null) {
+            command.setExecutor(new BloodChestCommand(configuration, menuManager));
+        } else {
+            getLogger().warning("Command blood_chest is not defined in plugin.yml");
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (sessionManager != null) {
+            sessionManager.shutdown();
+        }
+        if (pityManager != null) {
+            pityManager.save();
+        }
+    }
+
+    private void saveResourceIfMissing(String resourcePath) {
+        File target = new File(getDataFolder(), resourcePath);
+        if (!target.exists()) {
+            saveResource(resourcePath, false);
+        }
     }
 }

--- a/src/main/java/pl/yourserver/bloodChestPlugin/command/BloodChestCommand.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/command/BloodChestCommand.java
@@ -1,0 +1,35 @@
+package pl.yourserver.bloodChestPlugin.command;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.gui.MenuManager;
+
+public class BloodChestCommand implements CommandExecutor {
+
+    private final PluginConfiguration configuration;
+    private final MenuManager menuManager;
+
+    public BloodChestCommand(PluginConfiguration configuration, MenuManager menuManager) {
+        this.configuration = configuration;
+        this.menuManager = menuManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command is only available to players.");
+            return true;
+        }
+        String permission = configuration.getPermission();
+        if (permission != null && !permission.isEmpty() && !player.hasPermission(permission)) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
+            return true;
+        }
+        menuManager.openMainMenu(player);
+        return true;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
@@ -1,0 +1,219 @@
+package pl.yourserver.bloodChestPlugin.config;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.util.Vector;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSlot;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ChestSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.GuiSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.KeyRequirement;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.MenuButton;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.MobSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.MobSettings.SpawnMode;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.PitySettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.RewardSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.SchematicSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.SpawnLocation;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.TimeThreshold;
+import pl.yourserver.bloodChestPlugin.util.ConfigUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class ConfigurationLoader {
+
+    public PluginConfiguration load(FileConfiguration config) {
+        Objects.requireNonNull(config, "config");
+
+        String permission = config.getString("permission", "bloodchest.use");
+
+        GuiSettings guiSettings = readGuiSettings(config.getConfigurationSection("gui"));
+        KeyRequirement keyRequirement = readKeyRequirement(config.getConfigurationSection("key"));
+        PitySettings pitySettings = readPitySettings(config.getConfigurationSection("pity"));
+        ArenaSettings arenaSettings = readArenaSettings(config.getConfigurationSection("arena"));
+        RewardSettings rewardSettings = readRewardSettings(config.getConfigurationSection("rewards"));
+
+        return new PluginConfiguration(permission, guiSettings, keyRequirement, pitySettings, arenaSettings, rewardSettings);
+    }
+
+    private GuiSettings readGuiSettings(ConfigurationSection section) {
+        if (section == null) {
+            throw new IllegalStateException("Missing gui section in configuration");
+        }
+
+        String title = section.getString("title", "&8Blood Chest");
+        List<String> instructions = section.getStringList("instructions");
+
+        MenuButton startButton = readMenuButton(section.getConfigurationSection("start-button"), 13, Material.NETHER_STAR,
+                "&cStart Blood Chest", List.of("&7Consumes the required key"));
+        MenuButton lootButton = readMenuButton(section.getConfigurationSection("loot-button"), 15, Material.CHEST,
+                "&6View rewards", List.of("&7Show available loot"));
+        MenuButton closeButton = readMenuButton(section.getConfigurationSection("close-button"), 26, Material.BARRIER,
+                "&cClose", List.of("&7Close the menu"));
+        MenuButton backButton = readMenuButton(section.getConfigurationSection("back-button"), 45, Material.ARROW,
+                "&eBack", List.of("&7Return to the previous view"));
+
+        return new GuiSettings(title, instructions, startButton, lootButton, closeButton, backButton);
+    }
+
+    private MenuButton readMenuButton(ConfigurationSection section, int defaultSlot, Material defaultMaterial,
+                                       String defaultName, List<String> defaultLore) {
+        if (section == null) {
+            return new MenuButton(defaultSlot, defaultMaterial, defaultName, defaultLore);
+        }
+        int slot = section.getInt("slot", defaultSlot);
+        Material material = ConfigUtil.readMaterial(section.getString("material"), defaultMaterial);
+        String name = section.getString("name", defaultName);
+        List<String> lore = section.contains("lore") ? section.getStringList("lore") : defaultLore;
+        return new MenuButton(slot, material, name, lore);
+    }
+
+    private KeyRequirement readKeyRequirement(ConfigurationSection section) {
+        if (section == null) {
+            throw new IllegalStateException("Missing key section in configuration");
+        }
+        Material material = ConfigUtil.readMaterial(section.getString("material"), Material.IRON_NUGGET);
+        String displayName = section.getString("display-name", "&4Fragment of Infernal Passage");
+        int amount = section.getInt("amount", 25);
+        String pouchItemId = section.getString("pouch-item-id");
+        if (pouchItemId != null && pouchItemId.isBlank()) {
+            pouchItemId = null;
+        }
+        return new KeyRequirement(material, displayName, amount, pouchItemId);
+    }
+
+    private PitySettings readPitySettings(ConfigurationSection section) {
+        if (section == null) {
+            return new PitySettings(25, Collections.emptyList());
+        }
+        int threshold = Math.max(1, section.getInt("threshold", 25));
+        List<String> pool = section.getStringList("pool");
+        return new PitySettings(threshold, pool);
+    }
+
+    private ArenaSettings readArenaSettings(ConfigurationSection section) {
+        if (section == null) {
+            throw new IllegalStateException("Missing arena section in configuration");
+        }
+        String worldName = section.getString("world", "world");
+
+        SpawnLocation returnLocation = readSpawnLocation(section.getConfigurationSection("return-location"), worldName);
+        Vector playerSpawnOffset = ConfigUtil.readVector(section.getConfigurationSection("player-spawn-offset"));
+        Vector pasteOffset = ConfigUtil.readVector(section.getConfigurationSection("paste-offset"));
+        Vector regionSize = ConfigUtil.readVector(section.getConfigurationSection("region-size"));
+
+        if (regionSize == null) {
+            regionSize = new Vector(48, 32, 48);
+        }
+
+        ConfigurationSection markersSection = section.getConfigurationSection("markers");
+        Material mobMarker = markersSection == null ? Material.OBSIDIAN :
+                ConfigUtil.readMaterial(markersSection.getString("mob"), Material.OBSIDIAN);
+        Material chestMarker = markersSection == null ? Material.BARREL :
+                ConfigUtil.readMaterial(markersSection.getString("chest"), Material.BARREL);
+
+        List<ArenaSlot> slots = new ArrayList<>();
+        for (ConfigurationSection slotSection : ConfigUtil.children(section.getConfigurationSection("slots"))) {
+            String id = slotSection.getName();
+            ConfigurationSection originSection = slotSection.getConfigurationSection("origin");
+            if (originSection == null) {
+                throw new IllegalStateException("Slot " + id + " is missing origin");
+            }
+            SpawnLocation origin = readSpawnLocation(originSection, originSection.getString("world", worldName));
+            slots.add(new ArenaSlot(id, origin));
+        }
+        if (slots.isEmpty()) {
+            throw new IllegalStateException("No arena slots configured");
+        }
+
+        MobSettings mobSettings = readMobSettings(section.getConfigurationSection("mob"));
+        ChestSettings chestSettings = readChestSettings(section.getConfigurationSection("chest"));
+        SchematicSettings schematicSettings = readSchematicSettings(section.getConfigurationSection("schematic"));
+
+        return new ArenaSettings(worldName, returnLocation, playerSpawnOffset, pasteOffset, regionSize,
+                mobMarker, chestMarker, slots, mobSettings, chestSettings, schematicSettings);
+    }
+
+    private SpawnLocation readSpawnLocation(ConfigurationSection section, String defaultWorld) {
+        if (section == null) {
+            return new SpawnLocation(defaultWorld, 0.5, 80.0, 0.5, 0f, 0f);
+        }
+        String world = section.getString("world", defaultWorld);
+        double x = section.getDouble("x", 0.5);
+        double y = section.getDouble("y", 80.0);
+        double z = section.getDouble("z", 0.5);
+        float yaw = (float) section.getDouble("yaw", 0.0);
+        float pitch = (float) section.getDouble("pitch", 0.0);
+        return new SpawnLocation(world, x, y, z, yaw, pitch);
+    }
+
+    private MobSettings readMobSettings(ConfigurationSection section) {
+        if (section == null) {
+            return new MobSettings(SpawnMode.VANILLA, null, null, "MythicMob", EntityType.HUSK, 1);
+        }
+        String spawnModeRaw = section.getString("spawn-mode", "VANILLA");
+        SpawnMode spawnMode;
+        try {
+            spawnMode = SpawnMode.valueOf(spawnModeRaw.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            spawnMode = SpawnMode.VANILLA;
+        }
+
+        String mythicId = section.getString("mythic-id");
+        String command = section.getString("spawn-command", "mm mobs spawn {id} {world} {x} {y} {z}");
+        String metadataKey = section.getString("metadata-key", "MythicMob");
+        EntityType fallbackEntity = ConfigUtil.readEntityType(section.getString("fallback-entity"), EntityType.HUSK);
+        int spawnYOffset = section.getInt("y-offset", 1);
+
+        return new MobSettings(spawnMode, mythicId, command, metadataKey, fallbackEntity, spawnYOffset);
+    }
+
+    private ChestSettings readChestSettings(ConfigurationSection section) {
+        Material material = Material.CHEST;
+        String name = "&4Blood Chest";
+        List<String> lore = List.of("&7Open to claim your rewards");
+        if (section != null) {
+            material = ConfigUtil.readMaterial(section.getString("material"), material);
+            name = section.getString("name", name);
+            lore = section.contains("lore") ? section.getStringList("lore") : lore;
+        }
+        return new ChestSettings(material, name, lore);
+    }
+
+    private SchematicSettings readSchematicSettings(ConfigurationSection section) {
+        if (section == null) {
+            return new SchematicSettings("schematics/blood_chest", "arena.schem");
+        }
+        String folder = section.getString("folder", "schematics/blood_chest");
+        String file = section.getString("file", "arena.schem");
+        return new SchematicSettings(folder, file);
+    }
+
+    private RewardSettings readRewardSettings(ConfigurationSection section) {
+        List<TimeThreshold> thresholds = new ArrayList<>();
+        if (section != null) {
+            for (ConfigurationSection thresholdSection : ConfigUtil.children(section.getConfigurationSection("thresholds"))) {
+                int chestCount = thresholdSection.getInt("chest-count", 1);
+                int maxSeconds = thresholdSection.getInt("max-seconds", Integer.MAX_VALUE);
+                thresholds.add(new TimeThreshold(chestCount, maxSeconds));
+            }
+        }
+        if (thresholds.isEmpty()) {
+            thresholds.add(new TimeThreshold(5, 30));
+            thresholds.add(new TimeThreshold(4, 60));
+            thresholds.add(new TimeThreshold(3, 120));
+            thresholds.add(new TimeThreshold(2, 300));
+            thresholds.add(new TimeThreshold(1, Integer.MAX_VALUE));
+        }
+        thresholds.sort((a, b) -> Integer.compare(a.getMaxSeconds(), b.getMaxSeconds()));
+        int rollsPerChest = section == null ? 3 : Math.max(1, section.getInt("rolls-per-chest", 3));
+        int exitCountdown = section == null ? 60 : Math.max(1, section.getInt("exit-countdown-seconds", 60));
+        return new RewardSettings(thresholds, rollsPerChest, exitCountdown);
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/PluginConfiguration.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/PluginConfiguration.java
@@ -1,0 +1,466 @@
+package pl.yourserver.bloodChestPlugin.config;
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.util.Vector;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable snapshot of the plugin configuration.
+ */
+public class PluginConfiguration {
+
+    private final String permission;
+    private final GuiSettings guiSettings;
+    private final KeyRequirement keyRequirement;
+    private final PitySettings pitySettings;
+    private final ArenaSettings arenaSettings;
+    private final RewardSettings rewardSettings;
+
+    public PluginConfiguration(
+            String permission,
+            GuiSettings guiSettings,
+            KeyRequirement keyRequirement,
+            PitySettings pitySettings,
+            ArenaSettings arenaSettings,
+            RewardSettings rewardSettings
+    ) {
+        this.permission = Objects.requireNonNull(permission, "permission");
+        this.guiSettings = Objects.requireNonNull(guiSettings, "guiSettings");
+        this.keyRequirement = Objects.requireNonNull(keyRequirement, "keyRequirement");
+        this.pitySettings = Objects.requireNonNull(pitySettings, "pitySettings");
+        this.arenaSettings = Objects.requireNonNull(arenaSettings, "arenaSettings");
+        this.rewardSettings = Objects.requireNonNull(rewardSettings, "rewardSettings");
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public GuiSettings getGuiSettings() {
+        return guiSettings;
+    }
+
+    public KeyRequirement getKeyRequirement() {
+        return keyRequirement;
+    }
+
+    public PitySettings getPitySettings() {
+        return pitySettings;
+    }
+
+    public ArenaSettings getArenaSettings() {
+        return arenaSettings;
+    }
+
+    public RewardSettings getRewardSettings() {
+        return rewardSettings;
+    }
+
+    public static final class GuiSettings {
+        private final String title;
+        private final List<String> instructions;
+        private final MenuButton startButton;
+        private final MenuButton lootButton;
+        private final MenuButton closeButton;
+        private final MenuButton backButton;
+
+        public GuiSettings(String title,
+                           List<String> instructions,
+                           MenuButton startButton,
+                           MenuButton lootButton,
+                           MenuButton closeButton,
+                           MenuButton backButton) {
+            this.title = Objects.requireNonNull(title, "title");
+            this.instructions = List.copyOf(instructions);
+            this.startButton = Objects.requireNonNull(startButton, "startButton");
+            this.lootButton = Objects.requireNonNull(lootButton, "lootButton");
+            this.closeButton = Objects.requireNonNull(closeButton, "closeButton");
+            this.backButton = Objects.requireNonNull(backButton, "backButton");
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public List<String> getInstructions() {
+            return instructions;
+        }
+
+        public MenuButton getStartButton() {
+            return startButton;
+        }
+
+        public MenuButton getLootButton() {
+            return lootButton;
+        }
+
+        public MenuButton getCloseButton() {
+            return closeButton;
+        }
+
+        public MenuButton getBackButton() {
+            return backButton;
+        }
+    }
+
+    public static final class MenuButton {
+        private final int slot;
+        private final Material material;
+        private final String displayName;
+        private final List<String> lore;
+
+        public MenuButton(int slot, Material material, String displayName, List<String> lore) {
+            this.slot = slot;
+            this.material = Objects.requireNonNull(material, "material");
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+            this.lore = Collections.unmodifiableList(lore);
+        }
+
+        public int getSlot() {
+            return slot;
+        }
+
+        public Material getMaterial() {
+            return material;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public List<String> getLore() {
+            return lore;
+        }
+    }
+
+    public static final class KeyRequirement {
+        private final Material material;
+        private final String displayName;
+        private final int amount;
+        private final String pouchItemId;
+
+        public KeyRequirement(Material material, String displayName, int amount, String pouchItemId) {
+            this.material = Objects.requireNonNull(material, "material");
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+            this.amount = amount;
+            this.pouchItemId = pouchItemId;
+        }
+
+        public Material getMaterial() {
+            return material;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public int getAmount() {
+            return amount;
+        }
+
+        public Optional<String> getPouchItemId() {
+            return Optional.ofNullable(pouchItemId);
+        }
+    }
+
+    public static final class PitySettings {
+        private final int threshold;
+        private final List<String> pool;
+
+        public PitySettings(int threshold, List<String> pool) {
+            this.threshold = threshold;
+            this.pool = Collections.unmodifiableList(pool);
+        }
+
+        public int getThreshold() {
+            return threshold;
+        }
+
+        public List<String> getPool() {
+            return pool;
+        }
+    }
+
+    public static final class ArenaSettings {
+        private final String worldName;
+        private final SpawnLocation returnLocation;
+        private final Vector playerSpawnOffset;
+        private final Vector pasteOffset;
+        private final Vector regionSize;
+        private final Material mobMarkerMaterial;
+        private final Material chestMarkerMaterial;
+        private final List<ArenaSlot> slots;
+        private final MobSettings mobSettings;
+        private final ChestSettings chestSettings;
+        private final SchematicSettings schematicSettings;
+
+        public ArenaSettings(String worldName,
+                             SpawnLocation returnLocation,
+                             Vector playerSpawnOffset,
+                             Vector pasteOffset,
+                             Vector regionSize,
+                             Material mobMarkerMaterial,
+                             Material chestMarkerMaterial,
+                             List<ArenaSlot> slots,
+                             MobSettings mobSettings,
+                             ChestSettings chestSettings,
+                             SchematicSettings schematicSettings) {
+            this.worldName = Objects.requireNonNull(worldName, "worldName");
+            this.returnLocation = Objects.requireNonNull(returnLocation, "returnLocation");
+            this.playerSpawnOffset = playerSpawnOffset == null ? new Vector() : playerSpawnOffset.clone();
+            this.pasteOffset = pasteOffset == null ? new Vector() : pasteOffset.clone();
+            this.regionSize = Objects.requireNonNull(regionSize, "regionSize").clone();
+            this.mobMarkerMaterial = Objects.requireNonNull(mobMarkerMaterial, "mobMarkerMaterial");
+            this.chestMarkerMaterial = Objects.requireNonNull(chestMarkerMaterial, "chestMarkerMaterial");
+            this.slots = List.copyOf(slots);
+            this.mobSettings = Objects.requireNonNull(mobSettings, "mobSettings");
+            this.chestSettings = Objects.requireNonNull(chestSettings, "chestSettings");
+            this.schematicSettings = Objects.requireNonNull(schematicSettings, "schematicSettings");
+        }
+
+        public String getWorldName() {
+            return worldName;
+        }
+
+        public SpawnLocation getReturnLocation() {
+            return returnLocation;
+        }
+
+        public Vector getPlayerSpawnOffset() {
+            return playerSpawnOffset.clone();
+        }
+
+        public Vector getPasteOffset() {
+            return pasteOffset.clone();
+        }
+
+        public Vector getRegionSize() {
+            return regionSize.clone();
+        }
+
+        public Material getMobMarkerMaterial() {
+            return mobMarkerMaterial;
+        }
+
+        public Material getChestMarkerMaterial() {
+            return chestMarkerMaterial;
+        }
+
+        public List<ArenaSlot> getSlots() {
+            return slots;
+        }
+
+        public MobSettings getMobSettings() {
+            return mobSettings;
+        }
+
+        public ChestSettings getChestSettings() {
+            return chestSettings;
+        }
+
+        public SchematicSettings getSchematicSettings() {
+            return schematicSettings;
+        }
+    }
+
+    public static final class ArenaSlot {
+        private final String id;
+        private final SpawnLocation origin;
+
+        public ArenaSlot(String id, SpawnLocation origin) {
+            this.id = Objects.requireNonNull(id, "id");
+            this.origin = Objects.requireNonNull(origin, "origin");
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public SpawnLocation getOrigin() {
+            return origin;
+        }
+    }
+
+    public static final class SpawnLocation {
+        private final String world;
+        private final double x;
+        private final double y;
+        private final double z;
+        private final float yaw;
+        private final float pitch;
+
+        public SpawnLocation(String world, double x, double y, double z, float yaw, float pitch) {
+            this.world = Objects.requireNonNull(world, "world");
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.yaw = yaw;
+            this.pitch = pitch;
+        }
+
+        public String getWorld() {
+            return world;
+        }
+
+        public double getX() {
+            return x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public double getZ() {
+            return z;
+        }
+
+        public float getYaw() {
+            return yaw;
+        }
+
+        public float getPitch() {
+            return pitch;
+        }
+    }
+
+    public static final class MobSettings {
+        public enum SpawnMode {
+            VANILLA,
+            MYTHIC_COMMAND
+        }
+
+        private final SpawnMode spawnMode;
+        private final String mythicMobId;
+        private final String spawnCommand;
+        private final String metadataKey;
+        private final EntityType fallbackEntityType;
+        private final int spawnYOffset;
+
+        public MobSettings(SpawnMode spawnMode,
+                           String mythicMobId,
+                           String spawnCommand,
+                           String metadataKey,
+                           EntityType fallbackEntityType,
+                           int spawnYOffset) {
+            this.spawnMode = Objects.requireNonNull(spawnMode, "spawnMode");
+            this.mythicMobId = mythicMobId;
+            this.spawnCommand = spawnCommand;
+            this.metadataKey = metadataKey;
+            this.fallbackEntityType = fallbackEntityType == null ? EntityType.ZOMBIE : fallbackEntityType;
+            this.spawnYOffset = spawnYOffset;
+        }
+
+        public SpawnMode getSpawnMode() {
+            return spawnMode;
+        }
+
+        public String getMythicMobId() {
+            return mythicMobId;
+        }
+
+        public String getSpawnCommand() {
+            return spawnCommand;
+        }
+
+        public String getMetadataKey() {
+            return metadataKey;
+        }
+
+        public EntityType getFallbackEntityType() {
+            return fallbackEntityType;
+        }
+
+        public int getSpawnYOffset() {
+            return spawnYOffset;
+        }
+    }
+
+    public static final class ChestSettings {
+        private final Material chestMaterial;
+        private final String displayName;
+        private final List<String> lore;
+
+        public ChestSettings(Material chestMaterial, String displayName, List<String> lore) {
+            this.chestMaterial = Objects.requireNonNull(chestMaterial, "chestMaterial");
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+            this.lore = Collections.unmodifiableList(lore);
+        }
+
+        public Material getChestMaterial() {
+            return chestMaterial;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public List<String> getLore() {
+            return lore;
+        }
+    }
+
+    public static final class SchematicSettings {
+        private final String folder;
+        private final String file;
+
+        public SchematicSettings(String folder, String file) {
+            this.folder = Objects.requireNonNull(folder, "folder");
+            this.file = Objects.requireNonNull(file, "file");
+        }
+
+        public String getFolder() {
+            return folder;
+        }
+
+        public String getFile() {
+            return file;
+        }
+    }
+
+    public static final class RewardSettings {
+        private final List<TimeThreshold> thresholds;
+        private final int rollsPerChest;
+        private final int exitCountdownSeconds;
+
+        public RewardSettings(List<TimeThreshold> thresholds, int rollsPerChest, int exitCountdownSeconds) {
+            this.thresholds = List.copyOf(thresholds);
+            this.rollsPerChest = rollsPerChest;
+            this.exitCountdownSeconds = exitCountdownSeconds;
+        }
+
+        public List<TimeThreshold> getThresholds() {
+            return thresholds;
+        }
+
+        public int getRollsPerChest() {
+            return rollsPerChest;
+        }
+
+        public int getExitCountdownSeconds() {
+            return exitCountdownSeconds;
+        }
+    }
+
+    public static final class TimeThreshold {
+        private final int chestCount;
+        private final int maxSeconds;
+
+        public TimeThreshold(int chestCount, int maxSeconds) {
+            this.chestCount = chestCount;
+            this.maxSeconds = maxSeconds;
+        }
+
+        public int getChestCount() {
+            return chestCount;
+        }
+
+        public int getMaxSeconds() {
+            return maxSeconds;
+        }
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/LootOverviewMenu.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/LootOverviewMenu.java
@@ -1,0 +1,83 @@
+package pl.yourserver.bloodChestPlugin.gui;
+
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.GuiSettings;
+import pl.yourserver.bloodChestPlugin.loot.LootItemDefinition;
+import pl.yourserver.bloodChestPlugin.loot.LootRegistry;
+import pl.yourserver.bloodChestPlugin.util.ItemStackUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class LootOverviewMenu implements MenuView {
+
+    private static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.legacyAmpersand();
+
+    private final PluginConfiguration configuration;
+    private final MenuManager menuManager;
+    private final LootRegistry lootRegistry;
+    private final Inventory inventory;
+
+    public LootOverviewMenu(PluginConfiguration configuration, MenuManager menuManager, LootRegistry lootRegistry) {
+        this.configuration = configuration;
+        this.menuManager = menuManager;
+        this.lootRegistry = lootRegistry;
+        this.inventory = Bukkit.createInventory(null, 54, LEGACY.deserialize("&8Nagrody Blood Chest"));
+        build();
+    }
+
+    private void build() {
+        GuiSettings gui = configuration.getGuiSettings();
+        ItemStack filler = ItemStackUtil.createMenuItem(Material.BLACK_STAINED_GLASS_PANE, " ", List.of());
+        for (int i = 0; i < inventory.getSize(); i++) {
+            inventory.setItem(i, filler);
+        }
+        int slot = 0;
+        for (Map.Entry<String, List<LootItemDefinition>> entry : lootRegistry.getItemsByCategory().entrySet()) {
+            if (slot >= inventory.getSize()) {
+                break;
+            }
+            List<String> lore = new ArrayList<>();
+            List<LootItemDefinition> items = entry.getValue();
+            for (int i = 0; i < Math.min(items.size(), 10); i++) {
+                lore.add(ChatColor.GRAY + "- " + items.get(i).getDisplayName());
+            }
+            if (items.size() > 10) {
+                lore.add(ChatColor.DARK_GRAY + "... (" + (items.size() - 10) + " more)");
+            }
+            Material icon = items.isEmpty() ? Material.PAPER : items.get(0).getMaterial();
+            ItemStack stack = ItemStackUtil.createMenuItem(icon,
+                    "&6" + entry.getKey().toLowerCase().replace('_', ' '), lore);
+            inventory.setItem(slot++, stack);
+        }
+        inventory.setItem(gui.getBackButton().getSlot(), ItemStackUtil.createMenuItem(
+                gui.getBackButton().getMaterial(), gui.getBackButton().getDisplayName(), gui.getBackButton().getLore()));
+        inventory.setItem(gui.getCloseButton().getSlot(), ItemStackUtil.createMenuItem(
+                gui.getCloseButton().getMaterial(), gui.getCloseButton().getDisplayName(), gui.getCloseButton().getLore()));
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public void onClick(InventoryClickEvent event) {
+        GuiSettings gui = configuration.getGuiSettings();
+        int slot = event.getRawSlot();
+        if (slot == gui.getBackButton().getSlot()) {
+            menuManager.openMainMenu((Player) event.getWhoClicked());
+        } else if (slot == gui.getCloseButton().getSlot()) {
+            event.getWhoClicked().closeInventory();
+        }
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/MainMenuView.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/MainMenuView.java
@@ -1,0 +1,182 @@
+package pl.yourserver.bloodChestPlugin.gui;
+
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.GuiSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.KeyRequirement;
+import pl.yourserver.bloodChestPlugin.gui.MenuManager;
+import pl.yourserver.bloodChestPlugin.integration.IngredientPouchBridge;
+import pl.yourserver.bloodChestPlugin.session.SessionManager;
+import pl.yourserver.bloodChestPlugin.util.ItemStackUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MainMenuView implements MenuView {
+
+    private static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.legacyAmpersand();
+
+    private final PluginConfiguration configuration;
+    private final SessionManager sessionManager;
+    private final MenuManager menuManager;
+    private final IngredientPouchBridge pouchBridge;
+    private final Inventory inventory;
+    private final Player player;
+
+    public MainMenuView(PluginConfiguration configuration,
+                        SessionManager sessionManager,
+                        MenuManager menuManager,
+                        IngredientPouchBridge pouchBridge,
+                        Player player) {
+        this.configuration = configuration;
+        this.sessionManager = sessionManager;
+        this.menuManager = menuManager;
+        this.pouchBridge = pouchBridge;
+        this.player = player;
+        this.inventory = Bukkit.createInventory(null, 27, LEGACY.deserialize(configuration.getGuiSettings().getTitle()));
+        build();
+    }
+
+    private void build() {
+        GuiSettings gui = configuration.getGuiSettings();
+        ItemStack filler = ItemStackUtil.createMenuItem(Material.GRAY_STAINED_GLASS_PANE, " ", List.of());
+        for (int i = 0; i < inventory.getSize(); i++) {
+            inventory.setItem(i, filler);
+        }
+        ItemStack instructions = ItemStackUtil.createMenuItem(Material.BOOK, "&6Instrukcje", gui.getInstructions());
+        inventory.setItem(10, instructions);
+        inventory.setItem(gui.getStartButton().getSlot(), ItemStackUtil.createMenuItem(
+                gui.getStartButton().getMaterial(), gui.getStartButton().getDisplayName(), gui.getStartButton().getLore()));
+        inventory.setItem(gui.getLootButton().getSlot(), ItemStackUtil.createMenuItem(
+                gui.getLootButton().getMaterial(), gui.getLootButton().getDisplayName(), gui.getLootButton().getLore()));
+        inventory.setItem(gui.getCloseButton().getSlot(), ItemStackUtil.createMenuItem(
+                gui.getCloseButton().getMaterial(), gui.getCloseButton().getDisplayName(), gui.getCloseButton().getLore()));
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public void onClick(InventoryClickEvent event) {
+        GuiSettings gui = configuration.getGuiSettings();
+        int slot = event.getRawSlot();
+        if (slot == gui.getStartButton().getSlot()) {
+            attemptStart();
+        } else if (slot == gui.getLootButton().getSlot()) {
+            menuManager.openLootMenu(player);
+        } else if (slot == gui.getCloseButton().getSlot()) {
+            event.getWhoClicked().closeInventory();
+        }
+    }
+
+    private void attemptStart() {
+        if (sessionManager.getSession(player.getUniqueId()).isPresent()) {
+            player.sendMessage(color("&cYou are already inside a Blood Chest instance."));
+            return;
+        }
+        KeyRequirement key = configuration.getKeyRequirement();
+        if (!consumeKey(player, key)) {
+            player.sendMessage(color("&cYou need " + key.getAmount() + "x " + key.getDisplayName() + " to enter."));
+            return;
+        }
+        player.closeInventory();
+        Bukkit.getScheduler().runTask(sessionManager.getPlugin(), () -> {
+            try {
+                sessionManager.startSession(player);
+            } catch (Exception ex) {
+                player.sendMessage(color("&cFailed to start the instance: " + ex.getMessage()));
+                ex.printStackTrace();
+            }
+        });
+    }
+
+    private boolean consumeKey(Player player, KeyRequirement key) {
+        int needed = key.getAmount();
+        List<Integer> matchingSlots = new ArrayList<>();
+        int inventoryTotal = 0;
+        for (int i = 0; i < player.getInventory().getSize(); i++) {
+            ItemStack stack = player.getInventory().getItem(i);
+            if (stack == null || stack.getType() != key.getMaterial()) {
+                continue;
+            }
+            if (!matchesDisplayName(stack, key.getDisplayName())) {
+                continue;
+            }
+            inventoryTotal += stack.getAmount();
+            matchingSlots.add(i);
+            if (inventoryTotal >= needed) {
+                break;
+            }
+        }
+
+        int removeFromInventory = Math.min(needed, inventoryTotal);
+        int remaining = needed - removeFromInventory;
+        if (remaining > 0) {
+            if (pouchBridge == null || !pouchBridge.isAvailable() || key.getPouchItemId().isEmpty()) {
+                return false;
+            }
+            String pouchItemId = key.getPouchItemId().get();
+            int pouchQuantity = pouchBridge.getQuantity(player, pouchItemId);
+            if (pouchQuantity < remaining) {
+                return false;
+            }
+            if (!pouchBridge.withdraw(player, pouchItemId, remaining)) {
+                return false;
+            }
+        }
+
+        if (removeFromInventory > 0) {
+            deductFromInventory(matchingSlots, removeFromInventory);
+        }
+
+        player.updateInventory();
+        return true;
+    }
+
+    private void deductFromInventory(List<Integer> matchingSlots, int amountToRemove) {
+        int remaining = amountToRemove;
+        for (int slot : matchingSlots) {
+            if (remaining <= 0) {
+                break;
+            }
+            ItemStack stack = player.getInventory().getItem(slot);
+            if (stack == null) {
+                continue;
+            }
+            int remove = Math.min(stack.getAmount(), remaining);
+            stack.setAmount(stack.getAmount() - remove);
+            if (stack.getAmount() <= 0) {
+                player.getInventory().setItem(slot, null);
+            }
+            remaining -= remove;
+        }
+    }
+
+    private boolean matchesDisplayName(ItemStack stack, String requiredName) {
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null || meta.displayName() == null) {
+            return false;
+        }
+        String itemName = ChatColor.stripColor(LEGACY.serialize(meta.displayName()));
+        String needed = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', requiredName));
+        return itemName.equalsIgnoreCase(needed);
+    }
+
+    private String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/MenuManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/MenuManager.java
@@ -1,0 +1,96 @@
+package pl.yourserver.bloodChestPlugin.gui;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.plugin.Plugin;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.integration.IngredientPouchBridge;
+import pl.yourserver.bloodChestPlugin.loot.LootRegistry;
+import pl.yourserver.bloodChestPlugin.session.SessionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class MenuManager implements Listener {
+
+    private final Plugin plugin;
+    private final PluginConfiguration configuration;
+    private final SessionManager sessionManager;
+    private final LootRegistry lootRegistry;
+    private final IngredientPouchBridge pouchBridge;
+    private final Map<UUID, MenuView> menus = new HashMap<>();
+
+    public MenuManager(Plugin plugin,
+                       PluginConfiguration configuration,
+                       SessionManager sessionManager,
+                       LootRegistry lootRegistry,
+                       IngredientPouchBridge pouchBridge) {
+        this.plugin = plugin;
+        this.configuration = configuration;
+        this.sessionManager = sessionManager;
+        this.lootRegistry = lootRegistry;
+        this.pouchBridge = pouchBridge;
+    }
+
+    public void openMainMenu(Player player) {
+        MenuView menu = new MainMenuView(configuration, sessionManager, this, pouchBridge, player);
+        openMenu(player, menu);
+    }
+
+    public void openLootMenu(Player player) {
+        MenuView menu = new LootOverviewMenu(configuration, this, lootRegistry);
+        openMenu(player, menu);
+    }
+
+    private void openMenu(Player player, MenuView menu) {
+        menus.put(player.getUniqueId(), menu);
+        menu.onOpen(player);
+        player.openInventory(menu.getInventory());
+    }
+
+    public Optional<MenuView> getMenu(Player player) {
+        return Optional.ofNullable(menus.get(player.getUniqueId()));
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        MenuView menu = menus.get(player.getUniqueId());
+        if (menu == null) {
+            return;
+        }
+        if (!event.getInventory().equals(menu.getInventory())) {
+            return;
+        }
+        event.setCancelled(true);
+        menu.onClick(event);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        MenuView menu = menus.get(player.getUniqueId());
+        if (menu != null && menu.getInventory().equals(event.getInventory())) {
+            menus.remove(player.getUniqueId());
+            menu.onClose(event);
+        }
+    }
+
+    public Plugin getPlugin() {
+        return plugin;
+    }
+
+    public PluginConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/MenuView.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/MenuView.java
@@ -1,0 +1,19 @@
+package pl.yourserver.bloodChestPlugin.gui;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+
+public interface MenuView {
+
+    Inventory getInventory();
+
+    void onClick(InventoryClickEvent event);
+
+    default void onClose(InventoryCloseEvent event) {
+    }
+
+    default void onOpen(Player player) {
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/integration/IngredientPouchBridge.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/integration/IngredientPouchBridge.java
@@ -1,0 +1,133 @@
+package pl.yourserver.bloodChestPlugin.integration;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reflection-based bridge to the IngredientPouch plugin.
+ *
+ * <p>The BloodChest plugin cannot depend on the API at compile time, so we
+ * detect the plugin at runtime and access its public {@code PouchAPI}
+ * interface via reflection. When the plugin or API is unavailable, the bridge
+ * simply reports that no pouch support is present.</p>
+ */
+public class IngredientPouchBridge {
+
+    private static final String TARGET_PLUGIN = "IngredientPouchPlugin";
+
+    private final Logger logger;
+    private final Object apiInstance;
+    private final Method getItemQuantityMethod;
+    private final Method updateItemQuantityMethod;
+    private final Method hasPouchOpenMethod;
+    private final Method updatePouchGuiMethod;
+    private boolean available;
+
+    public IngredientPouchBridge(Logger logger) {
+        this.logger = logger;
+
+        Object api = null;
+        Method getQuantity = null;
+        Method updateQuantity = null;
+        Method hasOpen = null;
+        Method updateGui = null;
+        boolean bridgeAvailable = false;
+
+        try {
+            PluginManager pluginManager = Bukkit.getPluginManager();
+            Plugin pouchPlugin = pluginManager.getPlugin(TARGET_PLUGIN);
+            if (pouchPlugin != null && pouchPlugin.isEnabled()) {
+                Method getApiMethod = pouchPlugin.getClass().getMethod("getAPI");
+                api = getApiMethod.invoke(pouchPlugin);
+                if (api != null) {
+                    Class<?> apiClass = api.getClass();
+                    getQuantity = apiClass.getMethod("getItemQuantity", String.class, String.class);
+                    updateQuantity = apiClass.getMethod("updateItemQuantity", String.class, String.class, int.class);
+                    // Optional methods – not critical if missing.
+                    try {
+                        hasOpen = apiClass.getMethod("hasPouchOpen", Player.class);
+                        updateGui = apiClass.getMethod("updatePouchGUI", Player.class, String.class);
+                    } catch (NoSuchMethodException ignored) {
+                        hasOpen = null;
+                        updateGui = null;
+                    }
+                    bridgeAvailable = true;
+                    logger.info("[BloodChest] Connected to IngredientPouch API via reflection.");
+                }
+            }
+        } catch (Exception ex) {
+            logger.log(Level.WARNING, "[BloodChest] Failed to hook IngredientPouch API: " + ex.getMessage(), ex);
+        }
+
+        this.apiInstance = api;
+        this.getItemQuantityMethod = getQuantity;
+        this.updateItemQuantityMethod = updateQuantity;
+        this.hasPouchOpenMethod = hasOpen;
+        this.updatePouchGuiMethod = updateGui;
+        this.available = bridgeAvailable;
+    }
+
+    public boolean isAvailable() {
+        return available && apiInstance != null && getItemQuantityMethod != null && updateItemQuantityMethod != null;
+    }
+
+    public int getQuantity(Player player, String itemId) {
+        if (!isAvailable() || player == null || itemId == null || itemId.isEmpty()) {
+            return 0;
+        }
+        try {
+            UUID uuid = player.getUniqueId();
+            Object result = getItemQuantityMethod.invoke(apiInstance, uuid.toString(), itemId);
+            return result instanceof Number ? ((Number) result).intValue() : 0;
+        } catch (Exception ex) {
+            disableOnError(ex);
+            return 0;
+        }
+    }
+
+    public boolean withdraw(Player player, String itemId, int amount) {
+        if (!isAvailable() || player == null || itemId == null || itemId.isEmpty() || amount <= 0) {
+            return false;
+        }
+        try {
+            UUID uuid = player.getUniqueId();
+            Object result = updateItemQuantityMethod.invoke(apiInstance, uuid.toString(), itemId, -amount);
+            boolean success = !(result instanceof Boolean) || (Boolean) result;
+            if (success) {
+                notifyGui(player, itemId);
+            }
+            return success;
+        } catch (Exception ex) {
+            disableOnError(ex);
+            return false;
+        }
+    }
+
+    private void notifyGui(Player player, String itemId) {
+        if (hasPouchOpenMethod == null || updatePouchGuiMethod == null) {
+            return;
+        }
+        try {
+            Object open = hasPouchOpenMethod.invoke(apiInstance, player);
+            if (open instanceof Boolean && (Boolean) open) {
+                updatePouchGuiMethod.invoke(apiInstance, player, itemId);
+            }
+        } catch (Exception ex) {
+            // GUI sync failures should not disable the bridge; log at fine level.
+            logger.log(Level.FINE, "[BloodChest] Unable to refresh IngredientPouch GUI: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void disableOnError(Exception ex) {
+        logger.log(Level.WARNING, "[BloodChest] IngredientPouch API became unavailable: " + ex.getMessage(), ex);
+        available = false;
+    }
+}
+

--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootItemDefinition.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootItemDefinition.java
@@ -1,0 +1,83 @@
+package pl.yourserver.bloodChestPlugin.loot;
+
+import org.bukkit.Material;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class LootItemDefinition {
+
+    private final String id;
+    private final Material material;
+    private final String displayName;
+    private final String category;
+    private final List<String> lore;
+    private final int minAmount;
+    private final int maxAmount;
+    private final double weight;
+    private final int rolls;
+    private final double pityWeight;
+
+    public LootItemDefinition(String id,
+                              Material material,
+                              String displayName,
+                              String category,
+                              List<String> lore,
+                              int minAmount,
+                              int maxAmount,
+                              double weight,
+                              int rolls,
+                              double pityWeight) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.material = Objects.requireNonNull(material, "material");
+        this.displayName = Objects.requireNonNull(displayName, "displayName");
+        this.category = Objects.requireNonNull(category, "category");
+        this.lore = Collections.unmodifiableList(lore);
+        this.minAmount = minAmount;
+        this.maxAmount = Math.max(minAmount, maxAmount);
+        this.weight = weight;
+        this.rolls = Math.max(1, rolls);
+        this.pityWeight = pityWeight;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public List<String> getLore() {
+        return lore;
+    }
+
+    public int getMinAmount() {
+        return minAmount;
+    }
+
+    public int getMaxAmount() {
+        return maxAmount;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public int getRolls() {
+        return rolls;
+    }
+
+    public double getPityWeight() {
+        return pityWeight;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootLoader.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootLoader.java
@@ -1,0 +1,72 @@
+package pl.yourserver.bloodChestPlugin.loot;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import pl.yourserver.bloodChestPlugin.util.ConfigUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+public class LootLoader {
+
+    public LootRegistry load(File file) throws IOException, InvalidConfigurationException {
+        if (!file.exists()) {
+            throw new IOException("Missing loot configuration " + file.getAbsolutePath());
+        }
+        YamlConfiguration configuration = new YamlConfiguration();
+        configuration.load(file);
+
+        ConfigurationSection defaults = configuration.getConfigurationSection("defaults");
+        int defaultMin = defaults == null ? 1 : defaults.getInt("min-amount", 1);
+        int defaultMax = defaults == null ? 1 : defaults.getInt("max-amount", defaultMin);
+        double defaultWeight = defaults == null ? 1.0 : defaults.getDouble("weight", 1.0D);
+        int defaultRolls = defaults == null ? 1 : defaults.getInt("rolls", 1);
+        double defaultPityWeight = defaults == null ? 1.0 : defaults.getDouble("pity-weight", 1.0D);
+
+        ConfigurationSection lootSection = configuration.getConfigurationSection("loot");
+        if (lootSection == null) {
+            throw new InvalidConfigurationException("items.yml is missing the loot section");
+        }
+
+        List<LootItemDefinition> items = new ArrayList<>();
+        for (String categoryKey : lootSection.getKeys(false)) {
+            ConfigurationSection categorySection = lootSection.getConfigurationSection(categoryKey);
+            if (categorySection == null) {
+                continue;
+            }
+            String category = categoryKey.toUpperCase(Locale.ROOT);
+            for (String id : categorySection.getKeys(false)) {
+                ConfigurationSection itemSection = categorySection.getConfigurationSection(id);
+                if (itemSection == null) {
+                    continue;
+                }
+                Material material = ConfigUtil.readMaterial(itemSection.getString("material"), Material.PAPER);
+                String name = itemSection.getString("display-name", id);
+                List<String> lore = itemSection.getStringList("lore");
+                if (lore.isEmpty()) {
+                    String loreLine = itemSection.getString("lore-line");
+                    if (loreLine != null) {
+                        lore = List.of(loreLine);
+                    }
+                }
+                int min = itemSection.getInt("min-amount", defaultMin);
+                int max = itemSection.getInt("max-amount", defaultMax);
+                double weight = itemSection.getDouble("weight", defaultWeight);
+                int rolls = itemSection.getInt("rolls", defaultRolls);
+                double pityWeight = itemSection.getDouble("pity-weight", defaultPityWeight);
+
+                items.add(new LootItemDefinition(id, material, name, category, lore, min, max, weight, rolls, pityWeight));
+            }
+        }
+
+        Collection<String> pityPool = configuration.getStringList("pity-pool");
+
+        return new LootRegistry(items, pityPool);
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootRegistry.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootRegistry.java
@@ -1,0 +1,48 @@
+package pl.yourserver.bloodChestPlugin.loot;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LootRegistry {
+
+    private final Map<String, LootItemDefinition> itemsById;
+    private final Map<String, List<LootItemDefinition>> itemsByCategory;
+    private final List<LootItemDefinition> pityPool;
+
+    public LootRegistry(Collection<LootItemDefinition> items, Collection<String> pityPoolIds) {
+        this.itemsById = new HashMap<>();
+        this.itemsByCategory = new HashMap<>();
+        Objects.requireNonNull(items, "items").forEach(item -> {
+            itemsById.put(item.getId(), item);
+            itemsByCategory.computeIfAbsent(item.getCategory(), key -> new ArrayList<>()).add(item);
+        });
+        this.pityPool = pityPoolIds == null ? Collections.emptyList() : pityPoolIds.stream()
+                .map(itemsById::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public List<LootItemDefinition> getAll() {
+        return List.copyOf(itemsById.values());
+    }
+
+    public Map<String, List<LootItemDefinition>> getItemsByCategory() {
+        return itemsByCategory.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> List.copyOf(entry.getValue())));
+    }
+
+    public Optional<LootItemDefinition> getById(String id) {
+        return Optional.ofNullable(itemsById.get(id));
+    }
+
+    public List<LootItemDefinition> getPityPool() {
+        return pityPool;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootResult.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootResult.java
@@ -1,0 +1,25 @@
+package pl.yourserver.bloodChestPlugin.loot;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collections;
+import java.util.List;
+
+public class LootResult {
+
+    private final List<ItemStack> items;
+    private final boolean pityGranted;
+
+    public LootResult(List<ItemStack> items, boolean pityGranted) {
+        this.items = List.copyOf(items);
+        this.pityGranted = pityGranted;
+    }
+
+    public List<ItemStack> getItems() {
+        return items;
+    }
+
+    public boolean isPityGranted() {
+        return pityGranted;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootService.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootService.java
@@ -1,0 +1,65 @@
+package pl.yourserver.bloodChestPlugin.loot;
+
+import org.bukkit.inventory.ItemStack;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.session.PityManager;
+import pl.yourserver.bloodChestPlugin.util.ItemStackUtil;
+import pl.yourserver.bloodChestPlugin.util.WeightedPicker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class LootService {
+
+    private final LootRegistry registry;
+    private final PluginConfiguration.PitySettings pitySettings;
+    private final List<LootItemDefinition> allItems;
+    private final List<LootItemDefinition> pityPool;
+
+    public LootService(LootRegistry registry, PluginConfiguration.PitySettings pitySettings) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.pitySettings = Objects.requireNonNull(pitySettings, "pitySettings");
+        this.allItems = registry.getAll();
+        this.pityPool = registry.getPityPool();
+    }
+
+    public LootResult generateLoot(UUID playerId, int rollsPerChest, PityManager pityManager) {
+        List<ItemStack> drops = new ArrayList<>();
+        for (int i = 0; i < rollsPerChest; i++) {
+            LootItemDefinition definition = WeightedPicker.pick(allItems, LootItemDefinition::getWeight);
+            if (definition == null) {
+                continue;
+            }
+            for (int roll = 0; roll < definition.getRolls(); roll++) {
+                int amount = randomAmount(definition.getMinAmount(), definition.getMaxAmount());
+                drops.add(ItemStackUtil.createLootItem(definition, amount));
+            }
+        }
+
+        boolean pityGranted = false;
+        if (pityManager != null) {
+            int progress = pityManager.incrementAndGet(playerId);
+            if (progress >= pitySettings.getThreshold() && !pityPool.isEmpty()) {
+                LootItemDefinition pityDrop = WeightedPicker.pick(pityPool, LootItemDefinition::getPityWeight);
+                if (pityDrop != null) {
+                    int amount = randomAmount(pityDrop.getMinAmount(), pityDrop.getMaxAmount());
+                    drops.add(ItemStackUtil.createLootItem(pityDrop, amount));
+                    pityGranted = true;
+                }
+                pityManager.reset(playerId);
+            }
+        }
+
+        return new LootResult(drops, pityGranted);
+    }
+
+    private int randomAmount(int min, int max) {
+        if (max <= min) {
+            return Math.max(1, min);
+        }
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/ArenaSlotInstance.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/ArenaSlotInstance.java
@@ -1,0 +1,47 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSlot;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.SpawnLocation;
+
+import java.util.Objects;
+
+public class ArenaSlotInstance {
+
+    private final ArenaSlot configuration;
+    private final Location origin;
+    private boolean busy;
+
+    public ArenaSlotInstance(ArenaSlot configuration) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration");
+        this.origin = createLocation(configuration.getOrigin());
+        this.busy = false;
+    }
+
+    private Location createLocation(SpawnLocation spawnLocation) {
+        World world = Bukkit.getWorld(spawnLocation.getWorld());
+        if (world == null) {
+            throw new IllegalStateException("World " + spawnLocation.getWorld() + " is not loaded");
+        }
+        return new Location(world, spawnLocation.getX(), spawnLocation.getY(), spawnLocation.getZ(),
+                spawnLocation.getYaw(), spawnLocation.getPitch());
+    }
+
+    public boolean isBusy() {
+        return busy;
+    }
+
+    public void setBusy(boolean busy) {
+        this.busy = busy;
+    }
+
+    public Location getOrigin() {
+        return origin.clone();
+    }
+
+    public String getId() {
+        return configuration.getId();
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
@@ -1,0 +1,414 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.TileState;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ChestSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.MobSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.MobSettings.SpawnMode;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.RewardSettings;
+import pl.yourserver.bloodChestPlugin.loot.LootResult;
+import pl.yourserver.bloodChestPlugin.loot.LootService;
+import pl.yourserver.bloodChestPlugin.session.PityManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class BloodChestSession {
+
+    private final Plugin plugin;
+    private final PluginConfiguration configuration;
+    private final SchematicHandler schematicHandler;
+    private final LootService lootService;
+    private final PityManager pityManager;
+    private final ArenaSettings arenaSettings;
+    private final RewardSettings rewardSettings;
+    private final ArenaSlotInstance slot;
+    private final Location returnLocation;
+    private final File schematicFile;
+    private final SessionManager manager;
+
+    private Player player;
+    private Location pasteOrigin;
+    private final List<Location> mobSpawnLocations = new ArrayList<>();
+    private final List<Location> chestLocations = new ArrayList<>();
+    private final Map<Location, Boolean> spawnedChests = new HashMap<>();
+    private final Set<UUID> activeMobIds = new HashSet<>();
+    private final Set<UUID> defeatedMobIds = new HashSet<>();
+    private final List<Location> pendingSpawnAssignments = new ArrayList<>();
+    private long startTimeMillis;
+    private boolean mobsDefeated;
+    private boolean finished;
+    private BukkitRunnable exitCountdownTask;
+    private int exitCountdownSeconds;
+
+    public BloodChestSession(Plugin plugin,
+                             PluginConfiguration configuration,
+                             SchematicHandler schematicHandler,
+                             LootService lootService,
+                             PityManager pityManager,
+                             ArenaSlotInstance slot,
+                             Location returnLocation,
+                             File schematicFile,
+                             SessionManager manager) {
+        this.plugin = plugin;
+        this.configuration = configuration;
+        this.schematicHandler = schematicHandler;
+        this.lootService = lootService;
+        this.pityManager = pityManager;
+        this.arenaSettings = configuration.getArenaSettings();
+        this.rewardSettings = configuration.getRewardSettings();
+        this.slot = slot;
+        this.returnLocation = returnLocation;
+        this.schematicFile = schematicFile;
+        this.manager = manager;
+    }
+
+    public UUID getPlayerId() {
+        return player.getUniqueId();
+    }
+
+    public ArenaSlotInstance getSlot() {
+        return slot;
+    }
+
+    public void start(Player player) throws Exception {
+        this.player = player;
+        ensureSchematicExists();
+        this.pasteOrigin = slot.getOrigin().clone().add(arenaSettings.getPasteOffset());
+        World world = pasteOrigin.getWorld();
+        if (world == null) {
+            throw new IllegalStateException("World is not loaded for arena slot " + slot.getId());
+        }
+
+        schematicHandler.pasteSchematic(schematicFile, world, pasteOrigin);
+        scanMarkers(world);
+        teleportPlayerToArena();
+        this.startTimeMillis = System.currentTimeMillis();
+        spawnMobs(world);
+        player.sendMessage(color("&7Defeat all &cBlood Sludges &7as quickly as possible!"));
+    }
+
+    private void ensureSchematicExists() throws IOException {
+        if (!schematicFile.exists()) {
+            throw new IOException("Arena schematic not found: " + schematicFile.getAbsolutePath());
+        }
+    }
+
+    private void scanMarkers(World world) {
+        mobSpawnLocations.clear();
+        chestLocations.clear();
+        Vector size = arenaSettings.getRegionSize();
+        int baseX = pasteOrigin.getBlockX();
+        int baseY = pasteOrigin.getBlockY();
+        int baseZ = pasteOrigin.getBlockZ();
+
+        for (int x = 0; x < (int) size.getX(); x++) {
+            for (int y = 0; y < (int) size.getY(); y++) {
+                for (int z = 0; z < (int) size.getZ(); z++) {
+                    Block block = world.getBlockAt(baseX + x, baseY + y, baseZ + z);
+                    if (block.getType() == arenaSettings.getMobMarkerMaterial()) {
+                        Location spawnLocation = block.getLocation().add(0.5, 1 + arenaSettings.getMobSettings().getSpawnYOffset(), 0.5);
+                        mobSpawnLocations.add(spawnLocation);
+                        block.setType(Material.AIR, false);
+                    } else if (block.getType() == arenaSettings.getChestMarkerMaterial()) {
+                        chestLocations.add(block.getLocation());
+                        block.setType(Material.AIR, false);
+                    }
+                }
+            }
+        }
+    }
+
+    private void teleportPlayerToArena() {
+        Location destination = slot.getOrigin().clone().add(arenaSettings.getPlayerSpawnOffset());
+        player.teleport(destination);
+    }
+
+    private void spawnMobs(World world) {
+        MobSettings mobSettings = arenaSettings.getMobSettings();
+        int required = Math.min(5, mobSpawnLocations.size());
+        if (required <= 0) {
+            plugin.getLogger().warning("No mob spawn markers found for blood chest session");
+            return;
+        }
+        for (int i = 0; i < required; i++) {
+            Location spawnLocation = mobSpawnLocations.get(i);
+            if (mobSettings.getSpawnMode() == SpawnMode.MYTHIC_COMMAND) {
+                pendingSpawnAssignments.add(spawnLocation);
+                String command = buildSpawnCommand(mobSettings, spawnLocation);
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            } else {
+                EntityType type = mobSettings.getFallbackEntityType();
+                Entity entity = world.spawnEntity(spawnLocation, type);
+                entity.addScoreboardTag("blood_chest_mob");
+                activeMobIds.add(entity.getUniqueId());
+            }
+        }
+    }
+
+    private String buildSpawnCommand(MobSettings mobSettings, Location location) {
+        String command = mobSettings.getSpawnCommand();
+        if (command == null || command.isEmpty()) {
+            command = "mm mobs spawn {id} {world} {x} {y} {z}";
+        }
+        String id = mobSettings.getMythicMobId() != null ? mobSettings.getMythicMobId() : "";
+        return command
+                .replace("{id}", id)
+                .replace("{world}", location.getWorld().getName())
+                .replace("{x}", String.format(java.util.Locale.ROOT, "%.2f", location.getX()))
+                .replace("{y}", String.format(java.util.Locale.ROOT, "%.2f", location.getY()))
+                .replace("{z}", String.format(java.util.Locale.ROOT, "%.2f", location.getZ()));
+    }
+
+    public void handleEntitySpawn(Entity entity) {
+        if (finished) {
+            return;
+        }
+        MobSettings mobSettings = arenaSettings.getMobSettings();
+        if (mobSettings.getSpawnMode() != SpawnMode.MYTHIC_COMMAND) {
+            return;
+        }
+        if (!pendingSpawnAssignments.isEmpty()) {
+            if (mobSettings.getMetadataKey() != null && !mobSettings.getMetadataKey().isEmpty()) {
+                if (!entity.hasMetadata(mobSettings.getMetadataKey())) {
+                    return;
+                }
+            }
+            Iterator<Location> iterator = pendingSpawnAssignments.iterator();
+            while (iterator.hasNext()) {
+                Location expected = iterator.next();
+                if (expected.getWorld() == entity.getWorld() && expected.distanceSquared(entity.getLocation()) <= 4.0) {
+                    iterator.remove();
+                    activeMobIds.add(entity.getUniqueId());
+                    entity.addScoreboardTag("blood_chest_mob");
+                    break;
+                }
+            }
+        }
+    }
+
+    public void handleEntityDeath(Entity entity) {
+        if (finished) {
+            return;
+        }
+        if (!entity.getWorld().equals(pasteOrigin.getWorld())) {
+            return;
+        }
+        UUID uuid = entity.getUniqueId();
+        if (activeMobIds.remove(uuid)) {
+            defeatedMobIds.add(uuid);
+            checkMobsDefeated();
+            return;
+        }
+        MobSettings mobSettings = arenaSettings.getMobSettings();
+        if (mobSettings.getSpawnMode() == SpawnMode.MYTHIC_COMMAND) {
+            if (mobSettings.getMetadataKey() != null && !mobSettings.getMetadataKey().isEmpty()) {
+                if (!entity.hasMetadata(mobSettings.getMetadataKey())) {
+                    return;
+                }
+            }
+            if (isWithinArena(entity.getLocation())) {
+                defeatedMobIds.add(uuid);
+                checkMobsDefeated();
+            }
+        }
+    }
+
+    private boolean isWithinArena(Location location) {
+        if (location.getWorld() == null || !location.getWorld().equals(pasteOrigin.getWorld())) {
+            return false;
+        }
+        Vector size = arenaSettings.getRegionSize();
+        double minX = pasteOrigin.getBlockX();
+        double minY = pasteOrigin.getBlockY();
+        double minZ = pasteOrigin.getBlockZ();
+        return location.getX() >= minX && location.getX() <= minX + size.getX()
+                && location.getY() >= minY && location.getY() <= minY + size.getY()
+                && location.getZ() >= minZ && location.getZ() <= minZ + size.getZ();
+    }
+
+    private void checkMobsDefeated() {
+        if (mobsDefeated) {
+            return;
+        }
+        int required = Math.min(5, mobSpawnLocations.size());
+        if (defeatedMobIds.size() >= required && activeMobIds.isEmpty()) {
+            mobsDefeated = true;
+            onMobsDefeated();
+        }
+    }
+
+    private void onMobsDefeated() {
+        long elapsedSeconds = (System.currentTimeMillis() - startTimeMillis) / 1000L;
+        int chestCount = determineChestCount((int) elapsedSeconds);
+        player.sendMessage(color("&7All sludges were defeated in &e" + elapsedSeconds + "s&7!"));
+        spawnChests(chestCount);
+    }
+
+    private int determineChestCount(int elapsedSeconds) {
+        return rewardSettings.getThresholds().stream()
+                .filter(threshold -> elapsedSeconds <= threshold.getMaxSeconds())
+                .findFirst()
+                .map(PluginConfiguration.TimeThreshold::getChestCount)
+                .orElse(1);
+    }
+
+    private void spawnChests(int chestCount) {
+        ChestSettings chestSettings = arenaSettings.getChestSettings();
+        int available = Math.min(chestCount, chestLocations.size());
+        spawnedChests.clear();
+        for (int i = 0; i < available; i++) {
+            Location location = chestLocations.get(i);
+            Block block = location.getBlock();
+            block.setType(chestSettings.getChestMaterial(), false);
+            if (block.getState() instanceof TileState tileState) {
+                tileState.customName(Component.text(ChatColor.translateAlternateColorCodes('&', chestSettings.getDisplayName())));
+                List<Component> lore = chestSettings.getLore().stream()
+                        .map(line -> Component.text(ChatColor.translateAlternateColorCodes('&', line)))
+                        .toList();
+                tileState.lore(lore);
+                tileState.update();
+            }
+            spawnedChests.put(location, Boolean.FALSE);
+        }
+        player.sendMessage(color("&c" + available + " Blood Chests have appeared!"));
+    }
+
+    public boolean handleChestInteraction(Player clicker, Block block) {
+        if (finished || !clicker.getUniqueId().equals(player.getUniqueId())) {
+            return false;
+        }
+        Location location = block.getLocation();
+        Boolean opened = spawnedChests.get(location);
+        if (opened == null || opened) {
+            return false;
+        }
+        spawnedChests.put(location, Boolean.TRUE);
+        block.setType(Material.AIR, false);
+        LootResult result = lootService.generateLoot(player.getUniqueId(), rewardSettings.getRollsPerChest(), pityManager);
+        dropItems(location, result);
+        if (result.isPityGranted()) {
+            player.sendMessage(color("&6Pity drop granted!"));
+        }
+        if (spawnedChests.values().stream().allMatch(Boolean::booleanValue)) {
+            startExitCountdown();
+        }
+        return true;
+    }
+
+    private void dropItems(Location location, LootResult result) {
+        Location dropLocation = location.clone().add(0.5, 0.8, 0.5);
+        List<org.bukkit.inventory.ItemStack> items = result.getItems();
+        if (items.isEmpty()) {
+            return;
+        }
+        new BukkitRunnable() {
+            int index = 0;
+
+            @Override
+            public void run() {
+                if (index >= items.size()) {
+                    cancel();
+                    return;
+                }
+                org.bukkit.inventory.ItemStack item = items.get(index++);
+                org.bukkit.entity.Item dropped = dropLocation.getWorld().dropItem(dropLocation, item);
+                Vector velocity = new Vector(ThreadLocalRandom.current().nextGaussian() * 0.05,
+                        0.35, ThreadLocalRandom.current().nextGaussian() * 0.05);
+                dropped.setVelocity(velocity);
+            }
+        }.runTaskTimer(plugin, 0L, 10L);
+    }
+
+    private void startExitCountdown() {
+        if (exitCountdownTask != null) {
+            return;
+        }
+        exitCountdownSeconds = rewardSettings.getExitCountdownSeconds();
+        exitCountdownTask = new BukkitRunnable() {
+            int remaining = exitCountdownSeconds;
+
+            @Override
+            public void run() {
+                if (remaining <= 0) {
+                    cancel();
+                    exitCountdownTask = null;
+                    finishSession();
+                    return;
+                }
+                Title title = Title.title(Component.text(ChatColor.RED + "Returning in"),
+                        Component.text(ChatColor.GOLD + String.valueOf(remaining) + ChatColor.GRAY + " s"),
+                        Title.Times.times(Duration.ZERO, Duration.ofSeconds(1), Duration.ZERO));
+                player.showTitle(title);
+                remaining--;
+            }
+        };
+        exitCountdownTask.runTaskTimer(plugin, 0L, 20L);
+        player.sendMessage(color("&7You will be teleported in &e" + exitCountdownSeconds + "s"));
+    }
+
+    private void finishSession() {
+        if (finished) {
+            return;
+        }
+        finished = true;
+        if (exitCountdownTask != null) {
+            exitCountdownTask.cancel();
+            exitCountdownTask = null;
+        }
+        if (player.isOnline()) {
+            player.teleport(returnLocation);
+            player.sendMessage(color("&7Blood Chest challenge completed."));
+        }
+        if (pasteOrigin != null && pasteOrigin.getWorld() != null) {
+            schematicHandler.clearRegion(pasteOrigin.getWorld(), pasteOrigin, arenaSettings.getRegionSize());
+        }
+        manager.endSession(this);
+    }
+
+    public void handlePlayerQuit() {
+        forceStop();
+    }
+
+    public void forceStop() {
+        if (finished) {
+            return;
+        }
+        finished = true;
+        if (exitCountdownTask != null) {
+            exitCountdownTask.cancel();
+        }
+        if (pasteOrigin != null && pasteOrigin.getWorld() != null) {
+            schematicHandler.clearRegion(pasteOrigin.getWorld(), pasteOrigin, arenaSettings.getRegionSize());
+        }
+        manager.endSession(this);
+    }
+
+    private String color(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/PityManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/PityManager.java
@@ -1,0 +1,68 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PityManager {
+
+    private final Plugin plugin;
+    private final File file;
+    private final Map<UUID, Integer> progress = new HashMap<>();
+
+    public PityManager(Plugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "pity-data.yml");
+        load();
+    }
+
+    private void load() {
+        if (!file.exists()) {
+            return;
+        }
+        YamlConfiguration configuration = YamlConfiguration.loadConfiguration(file);
+        for (String key : configuration.getKeys(false)) {
+            try {
+                UUID uuid = UUID.fromString(key);
+                int value = configuration.getInt(key, 0);
+                progress.put(uuid, value);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    public int incrementAndGet(UUID uuid) {
+        int value = progress.getOrDefault(uuid, 0) + 1;
+        progress.put(uuid, value);
+        return value;
+    }
+
+    public void reset(UUID uuid) {
+        progress.remove(uuid);
+    }
+
+    public int get(UUID uuid) {
+        return progress.getOrDefault(uuid, 0);
+    }
+
+    public void save() {
+        YamlConfiguration configuration = new YamlConfiguration();
+        for (Map.Entry<UUID, Integer> entry : progress.entrySet()) {
+            configuration.set(entry.getKey().toString(), entry.getValue());
+        }
+        try {
+            File parent = file.getParentFile();
+            if (parent != null && !parent.exists()) {
+                parent.mkdirs();
+            }
+            configuration.save(file);
+        } catch (IOException ex) {
+            plugin.getLogger().warning("Failed to save pity data: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
@@ -1,0 +1,14 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.util.Vector;
+
+import java.io.File;
+
+public interface SchematicHandler {
+
+    void pasteSchematic(File schematicFile, World world, Location origin) throws Exception;
+
+    void clearRegion(World world, Location origin, Vector size);
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionListener.java
@@ -1,0 +1,52 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class SessionListener implements Listener {
+
+    private final SessionManager sessionManager;
+
+    public SessionListener(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
+        Player player = event.getPlayer();
+        boolean handled = sessionManager.handleChestInteract(player, block);
+        if (handled) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        sessionManager.handleEntityDeath(event.getEntity());
+    }
+
+    @EventHandler
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        sessionManager.handleEntitySpawn(event.getEntity());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        sessionManager.handlePlayerQuit(event.getPlayer());
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
@@ -1,0 +1,126 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSettings;
+import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.SpawnLocation;
+import pl.yourserver.bloodChestPlugin.loot.LootService;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class SessionManager {
+
+    private final Plugin plugin;
+    private final PluginConfiguration configuration;
+    private final SchematicHandler schematicHandler;
+    private final LootService lootService;
+    private final PityManager pityManager;
+    private final List<ArenaSlotInstance> slots = new ArrayList<>();
+    private final Map<UUID, BloodChestSession> sessions = new HashMap<>();
+    private final Location returnLocation;
+    private final File schematicFile;
+
+    public SessionManager(Plugin plugin,
+                          PluginConfiguration configuration,
+                          SchematicHandler schematicHandler,
+                          LootService lootService,
+                          PityManager pityManager) {
+        this.plugin = plugin;
+        this.configuration = configuration;
+        this.schematicHandler = schematicHandler;
+        this.lootService = lootService;
+        this.pityManager = pityManager;
+
+        ArenaSettings arenaSettings = configuration.getArenaSettings();
+        for (PluginConfiguration.ArenaSlot slot : arenaSettings.getSlots()) {
+            slots.add(new ArenaSlotInstance(slot));
+        }
+        this.returnLocation = toLocation(arenaSettings.getReturnLocation());
+        this.schematicFile = new File(plugin.getDataFolder(),
+                arenaSettings.getSchematicSettings().getFolder() + File.separator + arenaSettings.getSchematicSettings().getFile());
+    }
+
+    private Location toLocation(SpawnLocation spawnLocation) {
+        Location location = new Location(Bukkit.getWorld(spawnLocation.getWorld()),
+                spawnLocation.getX(), spawnLocation.getY(), spawnLocation.getZ(),
+                spawnLocation.getYaw(), spawnLocation.getPitch());
+        if (location.getWorld() == null) {
+            throw new IllegalStateException("World " + spawnLocation.getWorld() + " is not loaded");
+        }
+        return location;
+    }
+
+    public synchronized BloodChestSession startSession(Player player) throws Exception {
+        if (sessions.containsKey(player.getUniqueId())) {
+            throw new IllegalStateException("Player already has an active blood chest session");
+        }
+        ArenaSlotInstance slot = slots.stream().filter(s -> !s.isBusy()).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No arena instances are available. Please try again later."));
+        slot.setBusy(true);
+        BloodChestSession session = new BloodChestSession(plugin, configuration, schematicHandler, lootService, pityManager,
+                slot, returnLocation, schematicFile, this);
+        sessions.put(player.getUniqueId(), session);
+        session.start(player);
+        return session;
+    }
+
+    public synchronized void endSession(BloodChestSession session) {
+        sessions.remove(session.getPlayerId());
+        session.getSlot().setBusy(false);
+    }
+
+    public Optional<BloodChestSession> getSession(UUID playerId) {
+        return Optional.ofNullable(sessions.get(playerId));
+    }
+
+    public boolean handleChestInteract(Player player, Block block) {
+        BloodChestSession session = sessions.get(player.getUniqueId());
+        if (session != null) {
+            return session.handleChestInteraction(player, block);
+        }
+        return false;
+    }
+
+    public void handleEntityDeath(Entity entity) {
+        for (BloodChestSession session : sessions.values()) {
+            session.handleEntityDeath(entity);
+        }
+    }
+
+    public void handleEntitySpawn(Entity entity) {
+        for (BloodChestSession session : sessions.values()) {
+            session.handleEntitySpawn(entity);
+        }
+    }
+
+    public void handlePlayerQuit(Player player) {
+        BloodChestSession session = sessions.get(player.getUniqueId());
+        if (session != null) {
+            session.handlePlayerQuit();
+        }
+    }
+
+    public void shutdown() {
+        Collection<BloodChestSession> copy = new ArrayList<>(sessions.values());
+        for (BloodChestSession session : copy) {
+            session.forceStop();
+        }
+        sessions.clear();
+    }
+
+    public Plugin getPlugin() {
+        return plugin;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/WorldEditSchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/WorldEditSchematicHandler.java
@@ -1,0 +1,59 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.edit.SessionLimitExceededException;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
+import com.sk89q.worldedit.function.operation.Operation;
+import com.sk89q.worldedit.function.operation.Operations;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.session.ClipboardHolder;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.util.Vector;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class WorldEditSchematicHandler implements SchematicHandler {
+
+    @Override
+    public void pasteSchematic(File schematicFile, World world, Location origin) throws IOException {
+        ClipboardFormat format = ClipboardFormats.findByFile(schematicFile);
+        if (format == null) {
+            throw new IOException("Unsupported schematic format for file " + schematicFile.getAbsolutePath());
+        }
+        Clipboard clipboard;
+        try (ClipboardReader reader = format.getReader(new FileInputStream(schematicFile))) {
+            clipboard = reader.read();
+        }
+        BlockVector3 to = BlockVector3.at(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ());
+        try (com.sk89q.worldedit.EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
+            ClipboardHolder holder = new ClipboardHolder(clipboard);
+            Operation operation = holder
+                    .createPaste(editSession)
+                    .to(to)
+                    .ignoreAirBlocks(false)
+                    .build();
+            Operations.complete(operation);
+        } catch (SessionLimitExceededException ex) {
+            throw new IOException("Failed to paste schematic: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public void clearRegion(World world, Location origin, Vector size) {
+        BlockVector3 min = BlockVector3.at(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ());
+        BlockVector3 max = min.add((int) size.getX() - 1, (int) size.getY() - 1, (int) size.getZ() - 1);
+        try (com.sk89q.worldedit.EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
+            CuboidRegion region = new CuboidRegion(min, max);
+            editSession.setBlocks(region, BlockTypes.AIR.getDefaultState());
+        }
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/ConfigUtil.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/ConfigUtil.java
@@ -1,0 +1,63 @@
+package pl.yourserver.bloodChestPlugin.util;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.EntityType;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+public final class ConfigUtil {
+
+    private ConfigUtil() {
+    }
+
+    public static Material readMaterial(String value, Material fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Material.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return fallback;
+        }
+    }
+
+    public static EntityType readEntityType(String value, EntityType fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return EntityType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return fallback;
+        }
+    }
+
+    public static Vector readVector(ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        double x = section.getDouble("x", 0.0);
+        double y = section.getDouble("y", 0.0);
+        double z = section.getDouble("z", 0.0);
+        return new Vector(x, y, z);
+    }
+
+    public static List<ConfigurationSection> children(ConfigurationSection parent) {
+        if (parent == null) {
+            return Collections.emptyList();
+        }
+        List<ConfigurationSection> sections = new ArrayList<>();
+        for (String key : parent.getKeys(false)) {
+            ConfigurationSection child = parent.getConfigurationSection(key);
+            if (child != null) {
+                sections.add(child);
+            }
+        }
+        return sections;
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
@@ -1,0 +1,61 @@
+package pl.yourserver.bloodChestPlugin.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import pl.yourserver.bloodChestPlugin.loot.LootItemDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ItemStackUtil {
+
+    private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    private ItemStackUtil() {
+    }
+
+    public static ItemStack createMenuItem(Material material, String name, List<String> lore) {
+        ItemStack stack = new ItemStack(material);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.displayName(serialize(name));
+            if (lore != null && !lore.isEmpty()) {
+                List<Component> lines = new ArrayList<>();
+                for (String line : lore) {
+                    lines.add(serialize(line));
+                }
+                meta.lore(lines);
+            }
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    public static ItemStack createLootItem(LootItemDefinition definition, int amount) {
+        ItemStack stack = new ItemStack(definition.getMaterial());
+        stack.setAmount(Math.max(1, amount));
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.displayName(serialize(definition.getDisplayName()));
+            if (!definition.getLore().isEmpty()) {
+                List<Component> loreComponents = new ArrayList<>();
+                for (String line : definition.getLore()) {
+                    loreComponents.add(serialize(line));
+                }
+                meta.lore(loreComponents);
+            }
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    private static Component serialize(String input) {
+        if (input == null) {
+            return Component.empty();
+        }
+        return SERIALIZER.deserialize(input.replace("§", "&"));
+    }
+}

--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/WeightedPicker.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/WeightedPicker.java
@@ -1,0 +1,38 @@
+package pl.yourserver.bloodChestPlugin.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.ToDoubleFunction;
+
+public final class WeightedPicker {
+
+    private WeightedPicker() {
+    }
+
+    public static <T> T pick(List<T> elements, ToDoubleFunction<T> weightFunction) {
+        if (elements.isEmpty()) {
+            return null;
+        }
+        double totalWeight = 0.0D;
+        for (T element : elements) {
+            totalWeight += Math.max(0.0D, weightFunction.applyAsDouble(element));
+        }
+        if (totalWeight <= 0.0D) {
+            return elements.get(ThreadLocalRandom.current().nextInt(elements.size()));
+        }
+        double randomValue = ThreadLocalRandom.current().nextDouble() * totalWeight;
+        double cumulative = 0.0D;
+        for (T element : elements) {
+            cumulative += Math.max(0.0D, weightFunction.applyAsDouble(element));
+            if (randomValue <= cumulative) {
+                return element;
+            }
+        }
+        return elements.get(elements.size() - 1);
+    }
+
+    public static <T> T pick(Collection<T> elements, ToDoubleFunction<T> weightFunction) {
+        return pick(List.copyOf(elements), weightFunction);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,1 +1,140 @@
-key: addItem("ips", Material.IRON_NUGGET, "&4Fragment of Infernal Passage", "CURRENCY", "&7&oUsed to unlock the dangerous dungeons");
+permission: bloodchest.use
+
+gui:
+  title: "&8Blood Chest"
+  instructions:
+    - "&7Enter the arena solo and defeat &c5 Blood Sludges&7."
+    - "&7The faster you win, the more chests will appear."
+    - "&7Each run costs &c25 Fragment of Infernal Passage&7."
+  start-button:
+    slot: 13
+    material: NETHER_STAR
+    name: "&cStart Blood Chest"
+    lore:
+      - "&7Begin a new challenge."
+      - "&7Cost: &c25 Fragment of Infernal Passage"
+  loot-button:
+    slot: 15
+    material: CHEST
+    name: "&6View rewards"
+    lore:
+      - "&7Show all possible loot."
+  close-button:
+    slot: 26
+    material: BARRIER
+    name: "&cClose"
+    lore:
+      - "&7Close this menu."
+  back-button:
+    slot: 45
+    material: ARROW
+    name: "&eBack"
+    lore:
+      - "&7Return to the previous screen."
+
+key:
+  material: IRON_NUGGET
+  display-name: "&4Fragment of Infernal Passage"
+  amount: 25
+  pouch-item-id: ips
+
+pity:
+  threshold: 25
+  pool:
+    - grimmag_frag_I
+    - grimmag_frag_II
+    - grimmag_frag_III
+    - arachna_frag_I
+    - arachna_frag_II
+    - arachna_frag_III
+    - heredur_frag_I
+    - heredur_frag_II
+    - heredur_frag_III
+    - bearach_frag_I
+    - bearach_frag_II
+    - bearach_frag_III
+    - khalys_frag_I
+    - khalys_frag_II
+    - khalys_frag_III
+    - heralds_frag_I
+    - heralds_frag_II
+    - heralds_frag_III
+    - sigrismar_frag_I
+    - sigrismar_frag_II
+    - sigrismar_frag_III
+    - medusa_frag_I
+    - medusa_frag_II
+    - medusa_frag_III
+    - gorga_frag_I
+    - gorga_frag_II
+    - gorga_frag_III
+    - mortis_frag_I
+    - mortis_frag_II
+    - mortis_frag_III
+
+arena:
+  world: world
+  return-location:
+    world: world
+    x: 0.5
+    y: 80.0
+    z: 0.5
+    yaw: 0.0
+    pitch: 0.0
+  player-spawn-offset:
+    x: 0.5
+    y: 1.0
+    z: 0.5
+  paste-offset:
+    x: 0
+    y: 0
+    z: 0
+  region-size:
+    x: 64
+    y: 32
+    z: 64
+  markers:
+    mob: OBSIDIAN
+    chest: BARREL
+  schematic:
+    folder: schematics/blood_chest
+    file: arena.schem
+  chest:
+    material: CHEST
+    name: "&4Blood Chest"
+    lore:
+      - "&7Open to claim your rewards."
+  mob:
+    spawn-mode: MYTHIC_COMMAND
+    mythic-id: blood_sludge
+    spawn-command: "mm mobs spawn {id} {world} {x} {y} {z}"
+    metadata-key: MythicMob
+    fallback-entity: HUSK
+    y-offset: 1
+  slots:
+    slot-1:
+      origin:
+        world: world
+        x: 0
+        y: 80
+        z: 0
+
+rewards:
+  exit-countdown-seconds: 60
+  rolls-per-chest: 3
+  thresholds:
+    tier-5:
+      chest-count: 5
+      max-seconds: 30
+    tier-4:
+      chest-count: 4
+      max-seconds: 60
+    tier-3:
+      chest-count: 3
+      max-seconds: 120
+    tier-2:
+      chest-count: 2
+      max-seconds: 300
+    tier-1:
+      chest-count: 1
+      max-seconds: 2147483647

--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -1,283 +1,1683 @@
-    addItem("broken_armor_piece", Material.IRON_INGOT, "&2Broken Armor Piece", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("tousled_priest_robe", Material.SHULKER_SHELL, "&2Tousled Priest Robe", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("fur_black", Material.RABBIT_HIDE, "&2Black Fur", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("dragon_scale", Material.PHANTOM_MEMBRANE, "&2Dragon Scale", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("chain_fragment", Material.CHAIN, "&2Chain Fragment", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("satyrs_horn", Material.POINTED_DRIPSTONE, "&2Satyr`s Horn", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("gorgons_poison", Material.LIGHT_BLUE_DYE, "&2Gorgon`s Poison", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("dragon_gold", Material.GOLD_INGOT, "&2Dragon`s Gold", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("protectors_heart", Material.ORANGE_DYE, "&2Protector`s Heart", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("deaddd_bush", Material.DEAD_BUSH, "&2Dead Bush", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("demon_blood", Material.RED_DYE, "&dDemon Blood", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("sticky_mucus", Material.SLIME_BALL, "&dSticky Mucus", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("soul_of_an_acient_spartan", Material.PITCHER_POD, "&dSoul of an Acient Spartan", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("shadow_rose", Material.WITHER_ROSE, "&dShadow Rose", "EXPO", "&7&oCrafting and Quest resource");
-    addItem("Throphy_of_the_long_forgotten_bone_dragon", Material.DRAGON_HEAD, "&dThrophy of the Long Forgotten Bone Dragon", "EXPO", "&7&oCrafting and Quest resource");
-    
-    // Przedmioty z kategorii MONSTER_FRAGMENTS
-    addItem("mob_soul_I", Material.FLINT, "&9[ I ] Monster Soul Fragment", "MONSTER_FRAGMENTS", "&7&oBasic crafting material");
-    addItem("mob_soul_II", Material.FLINT, "&5[ II ] Monster Soul Fragment", "MONSTER_FRAGMENTS", "&7&oBasic crafting material");
-    addItem("mob_soul_III", Material.FLINT, "&6&6[ III ] Monster Soul Fragment ", "MONSTER_FRAGMENTS", "&7&oBasic crafting material");
-    
-    addItem("elite_heart_I", Material.NETHER_WART, "&9[ I ] Monster Heart Fragment", "MONSTER_FRAGMENTS", "&a&oRare crafting material");
-    addItem("elite_heart_II", Material.NETHER_WART, "&5[ II ] Monster Heart Fragment", "MONSTER_FRAGMENTS", "&a&oRare crafting material");
-    addItem("elite_heart_III", Material.NETHER_WART, "&6[ III ] Monster Heart Fragment", "MONSTER_FRAGMENTS", "&a&oRare crafting material");
-    // Przedmioty z kategorii Q - bossy
-    addItem("grimmag_frag_I", Material.LEATHER, "&9[ I ] Grimmage Burned Cape", "Q", "&c&oLegendary crafting material");
-    addItem("grimmag_frag_II", Material.LEATHER, "&5[ II ] Grimmage Burned Cape", "Q", "&c&oLegendary crafting material");
-    addItem("grimmag_frag_III", Material.LEATHER, "&6[ III ] Grimmage Burned Cape", "Q", "&c&oLegendary crafting material");
-    
-    addItem("arachna_frag_I", Material.PHANTOM_MEMBRANE, "&9[ I ] Arachana Poisonous Skeleton", "Q", "&c&oLegendary crafting material");
-    addItem("arachna_frag_II", Material.PHANTOM_MEMBRANE, "&5[ II ] Arachana Poisonous Skeleton", "Q", "&c&oLegendary crafting material");
-    addItem("arachna_frag_III", Material.PHANTOM_MEMBRANE, "&6[ III ] Arachana Poisonous Skeleton", "Q", "&c&oLegendary crafting material");
-    
-    addItem("heredur_frag_I", Material.PRISMARINE_CRYSTALS, "&9[ I ] Heredur`s Glacial Armor", "Q", "&c&oLegendary crafting material");
-    addItem("heredur_frag_II", Material.PRISMARINE_CRYSTALS, "&5[ II ] Heredur`s Glacial Armor", "Q", "&c&oLegendary crafting material");
-    addItem("heredur_frag_III", Material.PRISMARINE_CRYSTALS, "&6[ III ] Heredur`s Glacial Armor", "Q", "&c&oLegendary crafting material");
-    
-    addItem("bearach_frag_I", Material.HONEYCOMB, "&9[ I ] Bearach Honey Hide", "Q", "&c&oLegendary crafting material");
-    addItem("bearach_frag_II", Material.HONEYCOMB, "&5[ II ] Bearach Honey Hide", "Q", "&c&oLegendary crafting material");
-    addItem("bearach_frag_III", Material.HONEYCOMB, "&6[ III ] Bearach Honey Hide", "Q", "&c&oLegendary crafting material");
-    
-    addItem("khalys_frag_I", Material.BLACK_DYE, "&9[ I ] Khalys Magic Robe", "Q", "&c&oLegendary crafting material");
-    addItem("khalys_frag_II", Material.BLACK_DYE, "&5[ II ] Khalys Magic Robe", "Q", "&c&oLegendary crafting material");
-    addItem("khalys_frag_III", Material.BLACK_DYE, "&6[ III ] Khalys Magic Robe", "Q", "&c&oLegendary crafting material");
-    
-    addItem("heralds_frag_I", Material.NETHERITE_SCRAP, "&9[ I ] Herald`s Dragon Skin", "Q", "&c&oLegendary crafting material");
-    addItem("heralds_frag_II", Material.NETHERITE_SCRAP, "&5[ II ] Herald`s Dragon Skin", "Q", "&c&oLegendary crafting material");
-    addItem("heralds_frag_III", Material.NETHERITE_SCRAP, "&6[ III ] Herald`s Dragon Skin", "Q", "&c&oLegendary crafting material");
-    
-    addItem("sigrismar_frag_I", Material.AMETHYST_SHARD, "&9[ I ] Sigrismarr`s Eternal Ice", "Q", "&c&oLegendary crafting material");
-    addItem("sigrismar_frag_II", Material.AMETHYST_SHARD, "&5[ II ] Sigrismarr`s Eternal Ice", "Q", "&c&oLegendary crafting material");
-    addItem("sigrismar_frag_III", Material.AMETHYST_SHARD, "&6[ III ] Sigrismarr`s Eternal Ice", "Q", "&c&oLegendary crafting material");
-    
-    addItem("medusa_frag_I", Material.SCUTE, "&9[ I ] M`Edusa Stone Scales", "Q", "&c&oLegendary crafting material");
-    addItem("medusa_frag_II", Material.SCUTE, "&5[ II ] M`Edusa Stone Scales", "Q", "&c&oLegendary crafting material");
-    addItem("medusa_frag_III", Material.SCUTE, "&6[ III ] M`Edusa Stone Scales", "Q", "&c&oLegendary crafting material");
-    
-    addItem("gorga_frag_I", Material.LIGHTNING_ROD, "&9[ I ] Gorga`s Broken Tooth", "Q", "&c&oLegendary crafting material");
-    addItem("gorga_frag_II", Material.LIGHTNING_ROD, "&5[ II ] Gorga`s Broken Tooth", "Q", "&c&oLegendary crafting material");
-    addItem("gorga_frag_III", Material.LIGHTNING_ROD, "&6[ III ] Gorga`s Broken Tooth", "Q", "&c&oLegendary crafting material");
-    
-    addItem("mortis_frag_I", Material.BONE, "&9[ I ] Mortis Sacrificial Bones", "Q", "&c&oLegendary crafting material");
-    addItem("mortis_frag_II", Material.BONE, "&5[ II ] Mortis Sacrificial Bones", "Q", "&c&oLegendary crafting material");
-    addItem("mortis_frag_III", Material.BONE, "&6[ III ] Mortis Sacrificial Bones", "Q", "&c&oLegendary crafting material");
-    
-    // Przedmioty z kategorii KOPALNIA
-    addItem("ore_I", Material.COBBLESTONE, "&9[ I ] Ore", "KOPALNIA", "&7&oBasic crafting material");
-    addItem("ore_II", Material.COBBLESTONE, "&5[ II ] Ore", "KOPALNIA", "&7&oBasic crafting material");
-    addItem("ore_III", Material.COBBLESTONE, "&6[ III ] Ore", "KOPALNIA", "&7&oBasic crafting material");
-    
-    addItem("blood_I", Material.REDSTONE, "&9[ I ] Cursed Blood", "KOPALNIA", "&a&oRare crafting material");
-    addItem("blood_II", Material.REDSTONE, "&5[ II ] Cursed Blood", "KOPALNIA", "&a&oRare crafting material");
-    addItem("blood_III", Material.REDSTONE, "&6[ III ] Cursed Blood", "KOPALNIA", "&a&oRare crafting material");
-    
-    addItem("bone_I", Material.BONE, "&9[ I ] Shattered Bone", "KOPALNIA", "&a&oRare crafting material");
-    addItem("bone_II", Material.BONE, "&5[ II ] Shattered Bone", "KOPALNIA", "&a&oRare crafting material");
-    addItem("bone_III", Material.BONE, "&6[ III ] Shattered Bone", "KOPALNIA", "&a&oRare crafting material");
-    
-    addItem("leaf_I", Material.KELP, "&9[ I ] Leaf", "KOPALNIA", "&7&oBasic crafting material");
-    addItem("leaf_II", Material.KELP, "&5[ II ] Leaf", "KOPALNIA", "&7&oBasic crafting material");
-    addItem("leaf_III", Material.KELP, "&6[ III ] Leaf", "KOPALNIA", "&7&oBasic crafting material");
-    
-    // Items from category MINE
-    addItem("hematite", Material.COAL_ORE, "&8Hematite", "MINE",
-    "&7A common black ore with metallic luster and reddish streaks.",
-    "&eCoal-based mineral");
-    addItem("black_spinel", Material.COAL_ORE, "&8Black Spinel", "MINE",
-    "&7An uncommon black crystal with exceptional hardness and luster.",
-    "&eCoal-based gemstone");
-    addItem("black_diamond", Material.COAL_ORE, "&8&lBlack Diamond", "MINE",
-    "&7A rare and precious black diamond formed under extreme pressure.",
-    "&eHighest quality coal gem");
-    
-    addItem("magnetite", Material.IRON_ORE, "&7Magnetite", "MINE",
-    "&7A common metallic ore with magnetic properties.",
-    "&eIron-based mineral");
-    addItem("silver", Material.IRON_ORE, "&f&lSilver", "MINE",
-    "&7An uncommon precious metal with lustrous white appearance.",
-    "&eIron-based metal");
-    addItem("osmium", Material.IRON_ORE, "&7&lOsmium", "MINE",
-    "&7A rare and dense bluish-white metal, one of the heaviest natural elements.",
-    "&ePremium iron metal");
-    
-    addItem("azurite", Material.LAPIS_ORE, "&9Azurite", "MINE",
-    "&7A common deep blue mineral with intense azure color.",
-    "&eLapis-based mineral");
-    addItem("tanzanite", Material.LAPIS_ORE, "&9&lTanzanite", "MINE",
-    "&7An uncommon blue-purple gemstone known for its trichroic properties.",
-    "&eLapis-based gem");
-    addItem("blue_sapphire", Material.LAPIS_ORE, "&1&lBlue Sapphire", "MINE",
-    "&7A rare and precious blue gemstone, second only to diamond in hardness.",
-    "&ePremium lapis gem");
-    
-    addItem("carnelian", Material.REDSTONE_ORE, "&cCarnelian", "MINE",
-    "&7A common reddish-orange mineral with translucent properties.",
-    "&eRedstone-based mineral");
-    addItem("red_spinel", Material.REDSTONE_ORE, "&c&lRed Spinel", "MINE",
-    "&7An uncommon vibrant red gemstone often mistaken for ruby.",
-    "&eRedstone-based gem");
-    addItem("pigeon_blood_ruby", Material.REDSTONE_ORE, "&4&lPigeon Blood Ruby", "MINE",
-    "&7A rare and precious deep red gemstone with the coveted \"pigeon blood\" color.",
-    "&ePremium redstone gem");
-    
-    addItem("pyrite", Material.GOLD_ORE, "&ePyrite", "MINE",
-    "&7A common brassy-yellow mineral often called \"Fool`s Gold\".",
-    "&eGold-based mineral");
-    addItem("yellow_topaz", Material.GOLD_ORE, "&e&lYellow Topaz", "MINE",
-    "&7An uncommon golden-yellow gemstone with excellent clarity.",
-    "&eGold-based gem");
-    addItem("yellow_sapphire", Material.GOLD_ORE, "&6&lYellow Sapphire", "MINE",
-    "&7A rare and precious golden gemstone, prized for its brilliance and hardness.",
-    "&ePremium gold gem");
-    
-    addItem("malachite", Material.EMERALD_ORE, "&aMalachite", "MINE",
-    "&7A common green mineral with distinctive banded patterns.",
-    "&eEmerald-based mineral");
-    addItem("peridot", Material.EMERALD_ORE, "&a&lPeridot", "MINE",
-    "&7An uncommon olive-green gemstone formed in volcanic environments.",
-    "&eEmerald-based gem");
-    addItem("tropiche_emerald", Material.EMERALD_ORE, "&2&lTropiche Emerald", "MINE",
-    "&7A rare and precious deep green gemstone with exceptional clarity and color.",
-    "&ePremium emerald");
-    
-    addItem("danburite", Material.DIAMOND_ORE, "&fDanburite", "MINE",
-    "&7A common colorless crystal with diamond-like brilliance.",
-    "&eDiamond-based mineral");
-    addItem("goshenite", Material.DIAMOND_ORE, "&f&lGoshenite", "MINE",
-    "&7An uncommon colorless beryl with exceptional clarity.",
-    "&eDiamond-based gemstone");
-    addItem("cerussite", Material.DIAMOND_ORE, "&f&l&nCerussite", "MINE",
-    "&7A rare and precious crystal with the highest refractive index.",
-    "&eSupreme diamond gemstone");
-    
-    // Items from category FARMING
-    addItem("farmer_plant_fiber_I", Material.STRING, "&9[ I ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_plant_fiber_II", Material.STRING, "&5[ II ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_plant_fiber_III", Material.STRING, "&6[ III ] Plant Fiber", "FARMING", "&7&oBasic crafting material");
-    
-    addItem("farmer_seed_pouch_I", Material.WHEAT_SEEDS, "&9[ I ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_seed_pouch_II", Material.WHEAT_SEEDS, "&5[ II ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_seed_pouch_III", Material.WHEAT_SEEDS, "&6[ III ] Seed Pouch", "FARMING", "&7&oBasic crafting material");
-    
-    addItem("farmer_compost_dust_I", Material.BONE_MEAL, "&9[ I ] Compost Dust", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_compost_dust_II", Material.BONE_MEAL, "&5[ II ] Compost Dust", "FARMING", "&7&oBasic crafting material");
-    addItem("farmer_compost_dust_III", Material.BONE_MEAL, "&6[ III ] Compost Dust", "FARMING", "&7&oBasic crafting material");
-    
-    addItem("farmer_herb_extract_I", Material.SPIDER_EYE, "&9[ I ] Herbal Extract", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_herb_extract_II", Material.SPIDER_EYE, "&5[ II ] Herbal Extract", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_herb_extract_III", Material.SPIDER_EYE, "&6[ III ] Herbal Extract", "FARMING", "&a&oRare crafting material");
-    
-    addItem("farmer_mushroom_spores_I", Material.BROWN_MUSHROOM, "&9[ I ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_mushroom_spores_II", Material.BROWN_MUSHROOM, "&5[ II ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_mushroom_spores_III", Material.BROWN_MUSHROOM, "&6[ III ] Mushroom Spores", "FARMING", "&a&oRare crafting material");
-    
-    addItem("farmer_beeswax_chunk_I", Material.BOOK, "&9[ I ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_beeswax_chunk_II", Material.BOOK, "&5[ II ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
-    addItem("farmer_beeswax_chunk_III", Material.BOOK, "&6[ III ] Beeswax Chunk", "FARMING", "&a&oRare crafting material");
-    
-    addItem("farmer_druidic_essence_I", Material.GLOW_INK_SAC, "&9[ I ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_druidic_essence_II", Material.GLOW_INK_SAC, "&5[ II ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_druidic_essence_III", Material.GLOW_INK_SAC, "&6[ III ] Druidic Essence", "FARMING", "&c&oLegendary crafting material");
-    
-    addItem("farmer_golden_truffle_I", Material.GOLDEN_CARROT, "&9[ I ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_golden_truffle_II", Material.GOLDEN_CARROT, "&5[ II ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_golden_truffle_III", Material.GOLDEN_CARROT, "&6[ III ] Golden Truffle", "FARMING", "&c&oLegendary crafting material");
-    
-    addItem("farmer_ancient_grain_I", Material.HAY_BLOCK, "&9[ I ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_ancient_grain_II", Material.HAY_BLOCK, "&5[ II ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
-    addItem("farmer_ancient_grain_III", Material.HAY_BLOCK, "&6[ III ] Ancient Grain Sheaf", "FARMING", "&c&oLegendary crafting material");
-    
-    // Items from category BEES
-    addItem("honey_quality_basic", Material.HONEY_BOTTLE, "&9[ I ] Honey Bottle", "BEES",
-    "&7&oApplies a new &fQuality&7 to an item.",
-    "&7&oRoll range: &f-10% &7to &f+10%.",
-    "&7&oBasic crafting material");
-    addItem("honey_quality_rare", Material.HONEY_BOTTLE, "&5[ II ] Honey Bottle", "BEES",
-    "&7&oApplies a new &fQuality&7 to an item.",
-    "&7&oRoll range: &f0% &7to &f+20%.",
-    "&a&oRare crafting material");
-    addItem("honey_quality_legendary", Material.HONEY_BOTTLE, "&6[ III ] Honey Bottle", "BEES",
-    "&7&oApplies a new &fQuality&7 to an item.",
-    "&7&oRoll range: &f+10% &7to &f+30%.",
-    "&c&oLegendary crafting material");
-    
-    addItem("queen_bee_I", Material.BREAD, "&9[ I ] Queen Bee", "BEES",
-    "&7&oHive multiplier: &f1.0x",
-    "&7&oRarer honey chance: &a+5%");
-    addItem("queen_bee_II", Material.BREAD, "&5[ II ] Queen Bee", "BEES",
-    "&7&oHive multiplier: &f1.2x",
-    "&7&oRarer honey chance: &a+10%");
-    addItem("queen_bee_III", Material.BREAD, "&6[ III ] Queen Bee", "BEES",
-    "&7&oHive multiplier: &f1.5x",
-    "&7&oRarer honey chance: &a+15%");
-    
-    addItem("worker_bee_I", Material.BREAD, "&9[ I ] Worker Bee", "BEES",
-    "&7&oBase honey production: &f0.50");
-    addItem("worker_bee_II", Material.BREAD, "&5[ II ] Worker Bee", "BEES",
-    "&7&oBase honey production: &f0.75");
-    addItem("worker_bee_III", Material.BREAD, "&6[ III ] Worker Bee", "BEES",
-    "&7&oBase honey production: &f1.00");
-    
-    addItem("drone_bee_I", Material.BREAD, "&9[ I ] Drone Bee", "BEES",
-    "&7&oLarvae production: &f0.50",
-    "&7&oReduces base honey production: &f-1.00");
-    addItem("drone_bee_II", Material.BREAD, "&5[ II ] Drone Bee", "BEES",
-    "&7&oLarvae production: &f0.75",
-    "&7&oReduces base honey production: &f-0.75");
-    addItem("drone_bee_III", Material.BREAD, "&6[ III ] Drone Bee", "BEES",
-    "&7&oLarvae production: &f1.00",
-    "&7&oReduces base honey production: &f-0.50");
-    
-    addItem("larva_I", Material.COOKIE, "&9[ I ] Bee Larva", "BEES",
-    "&7&oCan transform into any type of bee.");
-    addItem("larva_II", Material.COOKIE, "&5[ II ] Bee Larva", "BEES",
-    "&7&oCan transform into any type of bee.");
-    addItem("larva_III", Material.COOKIE, "&6[ III ] Bee Larva", "BEES",
-    "&7&oCan transform into any type of bee.");
-    // Przedmioty z kategorii LOWISKO (Łowisko)
-    addItem("alga_I", Material.HORN_CORAL, "&9[ I ] Algal", "LOWISKO", "&7&oBasic crafting material");
-    addItem("alga_II", Material.HORN_CORAL, "&5[ II ] Algal", "LOWISKO", "&7&oBasic crafting material");
-    addItem("alga_III", Material.HORN_CORAL, "&6[ III ] Algal", "LOWISKO", "&7&oBasic crafting material");
-    
-    addItem("pearl_I", Material.TURTLE_EGG, "&9[ I ] Shiny Pearl", "LOWISKO", "&a&oRare crafting material");
-    addItem("pearl_II", Material.TURTLE_EGG, "&5[ II ] Shiny Pearl", "LOWISKO", "&a&oRare crafting material");
-    addItem("pearl_III", Material.TURTLE_EGG, "&6[ III ] Shiny Pearl", "LOWISKO", "&a&oRare crafting material");
-    
-    addItem("ocean_heart_I", Material.HEART_OF_THE_SEA, "&9[ I ] Heart of the Ocean", "LOWISKO", "&c&oLegendary crafting material");
-    addItem("ocean_heart_II", Material.HEART_OF_THE_SEA, "&5[ II ] Heart of the Ocean", "LOWISKO", "&c&oLegendary crafting material");
-    addItem("ocean_heart_III", Material.HEART_OF_THE_SEA, "&6[ III ] Heart of the Ocean", "LOWISKO", "&c&oLegendary crafting material");
-    
-    // Przedmioty z kategorii CURRENCY (Waluty)
-    addItem("draken", Material.GLISTERING_MELON_SLICE, "&e&lDrakenMelon", "CURRENCY", "&7&oEvent currency");
-    addItem("clover", Material.SUNFLOWER, "&6&lGlided Sunflower", "CURRENCY", "&7&oUnique currency");
-    addItem("andermant", Material.SMALL_AMETHYST_BUD, "&5&lAndermant", "CURRENCY", "&7&oPremium currency");
-    addItem("lockpick", Material.GREEN_DYE,"&8&lLockpick", "CURRENCY", "&7&oUsed to unlock mysterious chests");
-    addItem("jewel_dust", Material.INK_SAC, "§9Jewel Dust", "CURRENCY", "&7&oUsed to upgrade jewels");
-    addItem("shiny_dust", Material.GLOW_INK_SAC, "§5Shiny Dust", "CURRENCY", "&7&oUsed to upgrade gems");
-    addItem("rune_dust", Material.CLAY_BALL, "§cRune Dust", "CURRENCY", "&7&oUsed to upgrade runes");
-    addItem("crystal", Material.BRICK, "&d&lCrystal", "CURRENCY", "&7&oMine currency");
-    addItem("pota_biola", Material.BOWL, "&6Biologist Potion", "CURRENCY", "&7&oRight click to reset Biologist Cooldown");
-    addItem("essence_crystal", Material.QUARTZ, "&9Essence Crystal", "CURRENCY", "&7&oBasic crafting material");
-    addItem("power_crystal", Material.RAW_GOLD, "&5Power Crystal", "CURRENCY", "&a&oRare crafting material");
-    addItem("primordial_soul_crystal", Material.ECHO_SHARD, "&6Primordial Soul Crystal", "CURRENCY", "&c&oLegendary crafting material");
-    
-    // Items from category THREAD_WEAVING
-    // Basic Thread Weaving materials
-    addItem("thread_essence", Material.NETHER_BRICK, "&7Thread Essence", "THREAD_WEAVING", "&7&oBasic Thread Weaving material");
-    
-    // Rare Thread Weaving materials
-    addItem("shadow_thread_essence", Material.MAGMA_CREAM, "&5Shadow Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    addItem("undead_thread_essence", Material.MAGMA_CREAM, "&8Undead Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    addItem("fire_thread_essence", Material.MAGMA_CREAM, "&cFire Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    addItem("water_thread_essence", Material.MAGMA_CREAM, "&bWater Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    addItem("wild_thread_essence", Material.MAGMA_CREAM, "&aWild Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    addItem("poison_thread_essence", Material.MAGMA_CREAM, "&2Poison Thread Essence", "THREAD_WEAVING", "&a&oRare Thread Weaving material");
-    
-    // Legendary Thread Weaving materials
-    addItem("legendary_shadow_thread_essence", Material.RABBIT_FOOT, "&5&lLegendary Shadow Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
-    addItem("legendary_undead_thread_essence", Material.RABBIT_FOOT, "&8&lLegendary Undead Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
-    addItem("legendary_fire_thread_essence", Material.RABBIT_FOOT, "&c&lLegendary Fire Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
-    addItem("legendary_water_thread_essence", Material.RABBIT_FOOT, "&b&lLegendary Water Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
-    addItem("legendary_wild_thread_essence", Material.RABBIT_FOOT, "&a&lLegendary Wild Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
-    addItem("legendary_poison_thread_essence", Material.RABBIT_FOOT, "&2&lLegendary Poison Thread Essence", "THREAD_WEAVING", "&c&oLegendary Thread Weaving material");
+defaults:
+  min-amount: 1
+  max-amount: 1
+  weight: 1.0
+  rolls: 1
+  pity-weight: 1.0
+
+loot:
+  EXPO:
+    broken_armor_piece:
+      material: IRON_INGOT
+      display-name: "&2Broken Armor Piece"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    tousled_priest_robe:
+      material: SHULKER_SHELL
+      display-name: "&2Tousled Priest Robe"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    fur_black:
+      material: RABBIT_HIDE
+      display-name: "&2Black Fur"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    dragon_scale:
+      material: PHANTOM_MEMBRANE
+      display-name: "&2Dragon Scale"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    chain_fragment:
+      material: CHAIN
+      display-name: "&2Chain Fragment"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    satyrs_horn:
+      material: POINTED_DRIPSTONE
+      display-name: "&2Satyr's Horn"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    gorgons_poison:
+      material: LIGHT_BLUE_DYE
+      display-name: "&2Gorgon's Poison"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    dragon_gold:
+      material: GOLD_INGOT
+      display-name: "&2Dragon's Gold"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    protectors_heart:
+      material: ORANGE_DYE
+      display-name: "&2Protector's Heart"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    deaddd_bush:
+      material: DEAD_BUSH
+      display-name: "&2Dead Bush"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    demon_blood:
+      material: RED_DYE
+      display-name: "&dDemon Blood"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    sticky_mucus:
+      material: SLIME_BALL
+      display-name: "&dSticky Mucus"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    soul_of_an_acient_spartan:
+      material: PITCHER_POD
+      display-name: "&dSoul of an Acient Spartan"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    shadow_rose:
+      material: WITHER_ROSE
+      display-name: "&dShadow Rose"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    Throphy_of_the_long_forgotten_bone_dragon:
+      material: DRAGON_HEAD
+      display-name: "&dThrophy of the Long Forgotten Bone Dragon"
+      lore:
+        - "&7&oCrafting and Quest resource"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  MONSTER_FRAGMENTS:
+    mob_soul_I:
+      material: FLINT
+      display-name: "&9[ I ] Monster Soul Fragment"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    mob_soul_II:
+      material: FLINT
+      display-name: "&5[ II ] Monster Soul Fragment"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    mob_soul_III:
+      material: FLINT
+      display-name: "&6&6[ III ] Monster Soul Fragment "
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    elite_heart_I:
+      material: NETHER_WART
+      display-name: "&9[ I ] Monster Heart Fragment"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    elite_heart_II:
+      material: NETHER_WART
+      display-name: "&5[ II ] Monster Heart Fragment"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    elite_heart_III:
+      material: NETHER_WART
+      display-name: "&6[ III ] Monster Heart Fragment"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  Q:
+    grimmag_frag_I:
+      material: LEATHER
+      display-name: "&9[ I ] Grimmor`s Cindered Cape"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    grimmag_frag_II:
+      material: LEATHER
+      display-name: "&5[ II ] Grimmor`s Cindered Cape"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    grimmag_frag_III:
+      material: LEATHER
+      display-name: "&6[ III ] Grimmor`s Cindered Cape"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    arachna_frag_I:
+      material: PHANTOM_MEMBRANE
+      display-name: "&9[ I ] Araksha`s Venom Husk"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    arachna_frag_II:
+      material: PHANTOM_MEMBRANE
+      display-name: "&5[ II ] Araksha`s Venom Husk"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    arachna_frag_III:
+      material: PHANTOM_MEMBRANE
+      display-name: "&6[ III ] Araksha`s Venom Husk"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heredur_frag_I:
+      material: PRISMARINE_CRYSTALS
+      display-name: "&9[ I ] Heredorn`s Glacial Armor"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heredur_frag_II:
+      material: PRISMARINE_CRYSTALS
+      display-name: "&5[ II ] Heredorn`s Glacial Armor"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heredur_frag_III:
+      material: PRISMARINE_CRYSTALS
+      display-name: "&6[ III ] Heredorn`s Glacial Armor"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bearach_frag_I:
+      material: HONEYCOMB
+      display-name: "&9[ I ] Bearok Honey Hide"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bearach_frag_II:
+      material: HONEYCOMB
+      display-name: "&5[ II ] Bearok Honey Hide"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bearach_frag_III:
+      material: HONEYCOMB
+      display-name: "&6[ III ] Bearok Honey Hide"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    khalys_frag_I:
+      material: BLACK_DYE
+      display-name: "&9[ I ] Kalith`s Ritual Robe"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    khalys_frag_II:
+      material: BLACK_DYE
+      display-name: "&5[ II ] Kalith`s Ritual Robe"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    khalys_frag_III:
+      material: BLACK_DYE
+      display-name: "&6[ III ] Kalith`s Ritual Robe"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heralds_frag_I:
+      material: NETHERITE_SCRAP
+      display-name: "&9[ I ] Harbinger`s Dragon Skin"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heralds_frag_II:
+      material: NETHERITE_SCRAP
+      display-name: "&5[ II ] Harbinger`s Dragon Skin"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    heralds_frag_III:
+      material: NETHERITE_SCRAP
+      display-name: "&6[ III ] Harbinger`s Dragon Skin"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    sigrismar_frag_I:
+      material: AMETHYST_SHARD
+      display-name: "&9[ I ] Sigrosmar`s Eternal Ice"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    sigrismar_frag_II:
+      material: AMETHYST_SHARD
+      display-name: "&5[ II ] Sigrosmar`s Eternal Ice"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    sigrismar_frag_III:
+      material: AMETHYST_SHARD
+      display-name: "&6[ III ] Sigrosmar`s Eternal Ice"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    medusa_frag_I:
+      material: SCUTE
+      display-name: "&9[ I ] M`Edara Stone Scales"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    medusa_frag_II:
+      material: SCUTE
+      display-name: "&5[ II ] M`Edara Stone Scales"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    medusa_frag_III:
+      material: SCUTE
+      display-name: "&6[ III ] M`Edara Stone Scales"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    gorga_frag_I:
+      material: LIGHTNING_ROD
+      display-name: "&9[ I ] Gorgra`s Broken Tooth"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    gorga_frag_II:
+      material: LIGHTNING_ROD
+      display-name: "&5[ II ] Gorgra`s Broken Tooth"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    gorga_frag_III:
+      material: LIGHTNING_ROD
+      display-name: "&6[ III ] Gorgra`s Broken Tooth"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    mortis_frag_I:
+      material: BONE
+      display-name: "&9[ I ] Mortrix Sacrificial Bones"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    mortis_frag_II:
+      material: BONE
+      display-name: "&5[ II ] Mortrix Sacrificial Bones"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    mortis_frag_III:
+      material: BONE
+      display-name: "&6[ III ] Mortrix Sacrificial Bones"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  KOPALNIA:
+    ore_I:
+      material: COBBLESTONE
+      display-name: "&9[ I ] Ore"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    ore_II:
+      material: COBBLESTONE
+      display-name: "&5[ II ] Ore"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    ore_III:
+      material: COBBLESTONE
+      display-name: "&6[ III ] Ore"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    blood_I:
+      material: REDSTONE
+      display-name: "&9[ I ] Cursed Blood"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    blood_II:
+      material: REDSTONE
+      display-name: "&5[ II ] Cursed Blood"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    blood_III:
+      material: REDSTONE
+      display-name: "&6[ III ] Cursed Blood"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bone_I:
+      material: BONE
+      display-name: "&9[ I ] Shattered Bone"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bone_II:
+      material: BONE
+      display-name: "&5[ II ] Shattered Bone"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    bone_III:
+      material: BONE
+      display-name: "&6[ III ] Shattered Bone"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    leaf_I:
+      material: KELP
+      display-name: "&9[ I ] Leaf"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    leaf_II:
+      material: KELP
+      display-name: "&5[ II ] Leaf"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    leaf_III:
+      material: KELP
+      display-name: "&6[ III ] Leaf"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  MINE:
+    hematite:
+      material: COAL_ORE
+      display-name: "&8Hematite"
+      lore:
+        - "&7A common black ore with metallic luster and reddish streaks."
+        - "&eCoal-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    black_spinel:
+      material: COAL_ORE
+      display-name: "&8Black Spinel"
+      lore:
+        - "&7An uncommon black crystal with exceptional hardness and luster."
+        - "&eCoal-based gemstone"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    black_diamond:
+      material: COAL_ORE
+      display-name: "&8&lBlack Diamond"
+      lore:
+        - "&7A rare and precious black diamond formed under extreme pressure."
+        - "&eHighest quality coal gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    magnetite:
+      material: IRON_ORE
+      display-name: "&7Magnetite"
+      lore:
+        - "&7A common metallic ore with magnetic properties."
+        - "&eIron-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    silver:
+      material: IRON_ORE
+      display-name: "&f&lSilver"
+      lore:
+        - "&7An uncommon precious metal with lustrous white appearance."
+        - "&eIron-based metal"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    osmium:
+      material: IRON_ORE
+      display-name: "&7&lOsmium"
+      lore:
+        - "&7A rare and dense bluish-white metal, one of the heaviest natural elements."
+        - "&ePremium iron metal"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    azurite:
+      material: LAPIS_ORE
+      display-name: "&9Azurite"
+      lore:
+        - "&7A common deep blue mineral with intense azure color."
+        - "&eLapis-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    tanzanite:
+      material: LAPIS_ORE
+      display-name: "&9&lTanzanite"
+      lore:
+        - "&7An uncommon blue-purple gemstone known for its trichroic properties."
+        - "&eLapis-based gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    blue_sapphire:
+      material: LAPIS_ORE
+      display-name: "&1&lBlue Sapphire"
+      lore:
+        - "&7A rare and precious blue gemstone, second only to diamond in hardness."
+        - "&ePremium lapis gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    carnelian:
+      material: REDSTONE_ORE
+      display-name: "&cCarnelian"
+      lore:
+        - "&7A common reddish-orange mineral with translucent properties."
+        - "&eRedstone-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    red_spinel:
+      material: REDSTONE_ORE
+      display-name: "&c&lRed Spinel"
+      lore:
+        - "&7An uncommon vibrant red gemstone often mistaken for ruby."
+        - "&eRedstone-based gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pigeon_blood_ruby:
+      material: REDSTONE_ORE
+      display-name: "&4&lPigeon Blood Ruby"
+      lore:
+        - "&7A rare and precious deep red gemstone with the coveted "pigeon blood" color."
+        - "&ePremium redstone gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pyrite:
+      material: GOLD_ORE
+      display-name: "&ePyrite"
+      lore:
+        - "&7A common brassy-yellow mineral often called "Fool's Gold"."
+        - "&eGold-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    yellow_topaz:
+      material: GOLD_ORE
+      display-name: "&e&lYellow Topaz"
+      lore:
+        - "&7An uncommon golden-yellow gemstone with excellent clarity."
+        - "&eGold-based gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    yellow_sapphire:
+      material: GOLD_ORE
+      display-name: "&6&lYellow Sapphire"
+      lore:
+        - "&7A rare and precious golden gemstone, prized for its brilliance and hardness."
+        - "&ePremium gold gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    malachite:
+      material: EMERALD_ORE
+      display-name: "&aMalachite"
+      lore:
+        - "&7A common green mineral with distinctive banded patterns."
+        - "&eEmerald-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    peridot:
+      material: EMERALD_ORE
+      display-name: "&a&lPeridot"
+      lore:
+        - "&7An uncommon olive-green gemstone formed in volcanic environments."
+        - "&eEmerald-based gem"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    tropiche_emerald:
+      material: EMERALD_ORE
+      display-name: "&2&lTropiche Emerald"
+      lore:
+        - "&7A rare and precious deep green gemstone with exceptional clarity and color."
+        - "&ePremium emerald"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    danburite:
+      material: DIAMOND_ORE
+      display-name: "&fDanburite"
+      lore:
+        - "&7A common colorless crystal with diamond-like brilliance."
+        - "&eDiamond-based mineral"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    goshenite:
+      material: DIAMOND_ORE
+      display-name: "&f&lGoshenite"
+      lore:
+        - "&7An uncommon colorless beryl with exceptional clarity."
+        - "&eDiamond-based gemstone"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    cerussite:
+      material: DIAMOND_ORE
+      display-name: "&f&l&nCerussite"
+      lore:
+        - "&7A rare and precious crystal with the highest refractive index."
+        - "&eSupreme diamond gemstone"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  FARMING:
+    farmer_plant_fiber_I:
+      material: STRING
+      display-name: "&9[ I ] Plant Fiber"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_plant_fiber_II:
+      material: STRING
+      display-name: "&5[ II ] Plant Fiber"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_plant_fiber_III:
+      material: STRING
+      display-name: "&6[ III ] Plant Fiber"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_seed_pouch_I:
+      material: WHEAT_SEEDS
+      display-name: "&9[ I ] Seed Pouch"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_seed_pouch_II:
+      material: WHEAT_SEEDS
+      display-name: "&5[ II ] Seed Pouch"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_seed_pouch_III:
+      material: WHEAT_SEEDS
+      display-name: "&6[ III ] Seed Pouch"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_compost_dust_I:
+      material: BONE_MEAL
+      display-name: "&9[ I ] Compost Dust"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_compost_dust_II:
+      material: BONE_MEAL
+      display-name: "&5[ II ] Compost Dust"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_compost_dust_III:
+      material: BONE_MEAL
+      display-name: "&6[ III ] Compost Dust"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_herb_extract_I:
+      material: SPIDER_EYE
+      display-name: "&9[ I ] Herbal Extract"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_herb_extract_II:
+      material: SPIDER_EYE
+      display-name: "&5[ II ] Herbal Extract"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_herb_extract_III:
+      material: SPIDER_EYE
+      display-name: "&6[ III ] Herbal Extract"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_mushroom_spores_I:
+      material: BROWN_MUSHROOM
+      display-name: "&9[ I ] Mushroom Spores"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_mushroom_spores_II:
+      material: BROWN_MUSHROOM
+      display-name: "&5[ II ] Mushroom Spores"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_mushroom_spores_III:
+      material: BROWN_MUSHROOM
+      display-name: "&6[ III ] Mushroom Spores"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_beeswax_chunk_I:
+      material: BOOK
+      display-name: "&9[ I ] Beeswax Chunk"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_beeswax_chunk_II:
+      material: BOOK
+      display-name: "&5[ II ] Beeswax Chunk"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_beeswax_chunk_III:
+      material: BOOK
+      display-name: "&6[ III ] Beeswax Chunk"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_druidic_essence_I:
+      material: GLOW_INK_SAC
+      display-name: "&9[ I ] Druidic Essence"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_druidic_essence_II:
+      material: GLOW_INK_SAC
+      display-name: "&5[ II ] Druidic Essence"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_druidic_essence_III:
+      material: GLOW_INK_SAC
+      display-name: "&6[ III ] Druidic Essence"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_golden_truffle_I:
+      material: GOLDEN_CARROT
+      display-name: "&9[ I ] Golden Truffle"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_golden_truffle_II:
+      material: GOLDEN_CARROT
+      display-name: "&5[ II ] Golden Truffle"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_golden_truffle_III:
+      material: GOLDEN_CARROT
+      display-name: "&6[ III ] Golden Truffle"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_ancient_grain_I:
+      material: HAY_BLOCK
+      display-name: "&9[ I ] Ancient Grain Sheaf"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_ancient_grain_II:
+      material: HAY_BLOCK
+      display-name: "&5[ II ] Ancient Grain Sheaf"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    farmer_ancient_grain_III:
+      material: HAY_BLOCK
+      display-name: "&6[ III ] Ancient Grain Sheaf"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  BEES:
+    honey_quality_basic:
+      material: HONEY_BOTTLE
+      display-name: "&9[ I ] Honey Bottle"
+      lore:
+        - "&7&oApplies a new &fQuality&7 to an item."
+        - "&7&oRoll range: &f-10% &7to &f+10%."
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    honey_quality_rare:
+      material: HONEY_BOTTLE
+      display-name: "&5[ II ] Honey Bottle"
+      lore:
+        - "&7&oApplies a new &fQuality&7 to an item."
+        - "&7&oRoll range: &f0% &7to &f+20%."
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    honey_quality_legendary:
+      material: HONEY_BOTTLE
+      display-name: "&6[ III ] Honey Bottle"
+      lore:
+        - "&7&oApplies a new &fQuality&7 to an item."
+        - "&7&oRoll range: &f+10% &7to &f+30%."
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    queen_bee_I:
+      material: BREAD
+      display-name: "&9[ I ] Queen Bee"
+      lore:
+        - "&7&oHive multiplier: &f1.0x"
+        - "&7&oRarer honey chance: &a+5%"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    queen_bee_II:
+      material: BREAD
+      display-name: "&5[ II ] Queen Bee"
+      lore:
+        - "&7&oHive multiplier: &f1.2x"
+        - "&7&oRarer honey chance: &a+10%"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    queen_bee_III:
+      material: BREAD
+      display-name: "&6[ III ] Queen Bee"
+      lore:
+        - "&7&oHive multiplier: &f1.5x"
+        - "&7&oRarer honey chance: &a+15%"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    worker_bee_I:
+      material: BREAD
+      display-name: "&9[ I ] Worker Bee"
+      lore:
+        - "&7&oBase honey production: &f0.50"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    worker_bee_II:
+      material: BREAD
+      display-name: "&5[ II ] Worker Bee"
+      lore:
+        - "&7&oBase honey production: &f0.75"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    worker_bee_III:
+      material: BREAD
+      display-name: "&6[ III ] Worker Bee"
+      lore:
+        - "&7&oBase honey production: &f1.00"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    drone_bee_I:
+      material: BREAD
+      display-name: "&9[ I ] Drone Bee"
+      lore:
+        - "&7&oLarvae production: &f0.50"
+        - "&7&oReduces base honey production: &f-1.00"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    drone_bee_II:
+      material: BREAD
+      display-name: "&5[ II ] Drone Bee"
+      lore:
+        - "&7&oLarvae production: &f0.75"
+        - "&7&oReduces base honey production: &f-0.75"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    drone_bee_III:
+      material: BREAD
+      display-name: "&6[ III ] Drone Bee"
+      lore:
+        - "&7&oLarvae production: &f1.00"
+        - "&7&oReduces base honey production: &f-0.50"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    larva_I:
+      material: COOKIE
+      display-name: "&9[ I ] Bee Larva"
+      lore:
+        - "&7&oCan transform into any type of bee."
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    larva_II:
+      material: COOKIE
+      display-name: "&5[ II ] Bee Larva"
+      lore:
+        - "&7&oCan transform into any type of bee."
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    larva_III:
+      material: COOKIE
+      display-name: "&6[ III ] Bee Larva"
+      lore:
+        - "&7&oCan transform into any type of bee."
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  LOWISKO:
+    alga_I:
+      material: HORN_CORAL
+      display-name: "&9[ I ] Algal"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    alga_II:
+      material: HORN_CORAL
+      display-name: "&5[ II ] Algal"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    alga_III:
+      material: HORN_CORAL
+      display-name: "&6[ III ] Algal"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pearl_I:
+      material: TURTLE_EGG
+      display-name: "&9[ I ] Shiny Pearl"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pearl_II:
+      material: TURTLE_EGG
+      display-name: "&5[ II ] Shiny Pearl"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pearl_III:
+      material: TURTLE_EGG
+      display-name: "&6[ III ] Shiny Pearl"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    ocean_heart_I:
+      material: HEART_OF_THE_SEA
+      display-name: "&9[ I ] Heart of the Ocean"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    ocean_heart_II:
+      material: HEART_OF_THE_SEA
+      display-name: "&5[ II ] Heart of the Ocean"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    ocean_heart_III:
+      material: HEART_OF_THE_SEA
+      display-name: "&6[ III ] Heart of the Ocean"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  CURRENCY:
+    draken:
+      material: GLISTERING_MELON_SLICE
+      display-name: "&e&lDrakenMelon"
+      lore:
+        - "&7&oEvent currency"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    clover:
+      material: SUNFLOWER
+      display-name: "&6&lGlided Sunflower"
+      lore:
+        - "&7&oUnique currency"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    andermant:
+      material: SMALL_AMETHYST_BUD
+      display-name: "&5&lAnderium"
+      lore:
+        - "&7&oPremium currency"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    lockpick:
+      material: GREEN_DYE
+      display-name: "&8&lLockpick"
+      lore:
+        - "&7&oUsed to unlock mysterious chests"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    jewel_dust:
+      material: INK_SAC
+      display-name: "§9Jewel Dust"
+      lore:
+        - "&7&oUsed to upgrade jewels"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    shiny_dust:
+      material: GLOW_INK_SAC
+      display-name: "§5Shiny Dust"
+      lore:
+        - "&7&oUsed to upgrade gems"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    rune_dust:
+      material: CLAY_BALL
+      display-name: "§cRune Dust"
+      lore:
+        - "&7&oUsed to upgrade runes"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    crystal:
+      material: BRICK
+      display-name: "&d&lCrystal"
+      lore:
+        - "&7&oMine currency"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    pota_biola:
+      material: BOWL
+      display-name: "&6Biologist Potion"
+      lore:
+        - "&7&oRight click to reset Biologist Cooldown"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    essence_crystal:
+      material: QUARTZ
+      display-name: "&9Essence Crystal"
+      lore:
+        - "&7&oBasic crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    power_crystal:
+      material: RAW_GOLD
+      display-name: "&5Power Crystal"
+      lore:
+        - "&a&oRare crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    primordial_soul_crystal:
+      material: ECHO_SHARD
+      display-name: "&6Primordial Soul Crystal"
+      lore:
+        - "&c&oLegendary crafting material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+  THREAD_WEAVING:
+    thread_essence:
+      material: NETHER_BRICK
+      display-name: "&7Thread Essence"
+      lore:
+        - "&7&oBasic Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    shadow_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&5Shadow Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    undead_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&8Undead Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    fire_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&cFire Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    water_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&bWater Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    wild_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&aWild Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    poison_thread_essence:
+      material: MAGMA_CREAM
+      display-name: "&2Poison Thread Essence"
+      lore:
+        - "&a&oRare Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_shadow_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&5&lLegendary Shadow Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_undead_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&8&lLegendary Undead Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_fire_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&c&lLegendary Fire Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_water_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&b&lLegendary Water Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_wild_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&a&lLegendary Wild Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+    legendary_poison_thread_essence:
+      material: RABBIT_FOOT
+      display-name: "&2&lLegendary Poison Thread Essence"
+      lore:
+        - "&c&oLegendary Thread Weaving material"
+      min-amount: 1
+      max-amount: 1
+      weight: 1.0
+      rolls: 1
+      pity-weight: 1.0
+
+pity-pool:
+  - grimmag_frag_I
+  - grimmag_frag_II
+  - grimmag_frag_III
+  - arachna_frag_I
+  - arachna_frag_II
+  - arachna_frag_III
+  - heredur_frag_I
+  - heredur_frag_II
+  - heredur_frag_III
+  - bearach_frag_I
+  - bearach_frag_II
+  - bearach_frag_III
+  - khalys_frag_I
+  - khalys_frag_II
+  - khalys_frag_III
+  - heralds_frag_I
+  - heralds_frag_II
+  - heralds_frag_III
+  - sigrismar_frag_I
+  - sigrismar_frag_II
+  - sigrismar_frag_III
+  - medusa_frag_I
+  - medusa_frag_II
+  - medusa_frag_III
+  - gorga_frag_I
+  - gorga_frag_II
+  - gorga_frag_III
+  - mortis_frag_I
+  - mortis_frag_II
+  - mortis_frag_III

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,15 @@ name: bloodChestPlugin
 version: '1.0-SNAPSHOT'
 main: pl.yourserver.bloodChestPlugin.BloodChestPlugin
 api-version: '1.20'
+commands:
+  blood_chest:
+    description: Open the Blood Chest interface.
+    permission: bloodchest.use
+    usage: /blood_chest
+permissions:
+  bloodchest.use:
+    description: Allows a player to start the Blood Chest challenge.
+    default: false
+  bloodchest.admin:
+    description: Administrative access to Blood Chest features.
+    default: op


### PR DESCRIPTION
## Summary
- translate the default GUI labels and instructions in config.yml to English for the live server
- update fallback GUI button labels and menu tooltips to English in ConfigurationLoader and LootOverviewMenu
- localize all player-facing messages in command, menu, and session handling classes to English wording

## Testing
- `mvn -DskipTests package` *(fails: package com.sk89q.worldedit.edit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68d4283341ec832aafac0000f4a3aac8