### PR TITLE
Translate plugin messaging to English

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/command/BloodChestCommand.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/command/BloodChestCommand.java
@@ -21,12 +21,12 @@ public class BloodChestCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(ChatColor.RED + "Ta komenda dostępna jest tylko dla graczy.");
+            sender.sendMessage(ChatColor.RED + "This command is only available to players.");
             return true;
         }
         String permission = configuration.getPermission();
         if (permission != null && !permission.isEmpty() && !player.hasPermission(permission)) {
-            player.sendMessage(ChatColor.RED + "Nie masz uprawnień do użycia tej komendy.");
+            player.sendMessage(ChatColor.RED + "You do not have permission to use this command.");
             return true;
         }
         menuManager.openMainMenu(player);

--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
@@ -51,13 +51,13 @@ public class ConfigurationLoader {
         List<String> instructions = section.getStringList("instructions");
 
         MenuButton startButton = readMenuButton(section.getConfigurationSection("start-button"), 13, Material.NETHER_STAR,
-                "&cStart Blood Chest", List.of("&7Zużywa wymagany klucz"));
+                "&cStart Blood Chest", List.of("&7Consumes the required key"));
         MenuButton lootButton = readMenuButton(section.getConfigurationSection("loot-button"), 15, Material.CHEST,
-                "&6Możliwe nagrody", List.of("&7Wyświetl dostępne łupy"));
+                "&6Possible rewards", List.of("&7View the available loot"));
         MenuButton closeButton = readMenuButton(section.getConfigurationSection("close-button"), 26, Material.BARRIER,
-                "&cZamknij", List.of("&7Zamknij menu"));
+                "&cClose", List.of("&7Close the menu"));
         MenuButton backButton = readMenuButton(section.getConfigurationSection("back-button"), 45, Material.ARROW,
-                "&ePowrót", List.of("&7Wróć do poprzedniego widoku"));
+                "&eBack", List.of("&7Return to the previous view"));
 
         return new GuiSettings(title, instructions, startButton, lootButton, closeButton, backButton);
     }
@@ -177,7 +177,7 @@ public class ConfigurationLoader {
     private ChestSettings readChestSettings(ConfigurationSection section) {
         Material material = Material.CHEST;
         String name = "&4Blood Chest";
-        List<String> lore = List.of("&7Otwórz, aby odebrać nagrody");
+        List<String> lore = List.of("&7Open to claim your rewards");
         if (section != null) {
             material = ConfigUtil.readMaterial(section.getString("material"), material);
             name = section.getString("name", name);

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/LootOverviewMenu.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/LootOverviewMenu.java
@@ -31,7 +31,7 @@ public class LootOverviewMenu implements MenuView {
         this.configuration = configuration;
         this.menuManager = menuManager;
         this.lootRegistry = lootRegistry;
-        this.inventory = Bukkit.createInventory(null, 54, LEGACY.deserialize("&8Nagrody Blood Chest"));
+        this.inventory = Bukkit.createInventory(null, 54, LEGACY.deserialize("&8Blood Chest Rewards"));
         build();
     }
 
@@ -52,7 +52,7 @@ public class LootOverviewMenu implements MenuView {
                 lore.add(ChatColor.GRAY + "- " + items.get(i).getDisplayName());
             }
             if (items.size() > 10) {
-                lore.add(ChatColor.DARK_GRAY + "... (" + (items.size() - 10) + " więcej)");
+                lore.add(ChatColor.DARK_GRAY + "... (" + (items.size() - 10) + " more)");
             }
             Material icon = items.isEmpty() ? Material.PAPER : items.get(0).getMaterial();
             ItemStack stack = ItemStackUtil.createMenuItem(icon,

--- a/src/main/java/pl/yourserver/bloodChestPlugin/gui/MainMenuView.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/gui/MainMenuView.java
@@ -51,7 +51,7 @@ public class MainMenuView implements MenuView {
         for (int i = 0; i < inventory.getSize(); i++) {
             inventory.setItem(i, filler);
         }
-        ItemStack instructions = ItemStackUtil.createMenuItem(Material.BOOK, "&6Instrukcje", gui.getInstructions());
+        ItemStack instructions = ItemStackUtil.createMenuItem(Material.BOOK, "&6Instructions", gui.getInstructions());
         inventory.setItem(10, instructions);
         inventory.setItem(gui.getStartButton().getSlot(), ItemStackUtil.createMenuItem(
                 gui.getStartButton().getMaterial(), gui.getStartButton().getDisplayName(), gui.getStartButton().getLore()));
@@ -81,12 +81,12 @@ public class MainMenuView implements MenuView {
 
     private void attemptStart() {
         if (sessionManager.getSession(player.getUniqueId()).isPresent()) {
-            player.sendMessage(color("&cJuż znajdujesz się w instancji Blood Chest."));
+            player.sendMessage(color("&cYou are already inside a Blood Chest instance."));
             return;
         }
         KeyRequirement key = configuration.getKeyRequirement();
         if (!consumeKey(player, key)) {
-            player.sendMessage(color("&cPotrzebujesz " + key.getAmount() + "x " + key.getDisplayName() + " aby wejść."));
+            player.sendMessage(color("&cYou need " + key.getAmount() + "x " + key.getDisplayName() + " to enter."));
             return;
         }
         player.closeInventory();
@@ -94,7 +94,7 @@ public class MainMenuView implements MenuView {
             try {
                 sessionManager.startSession(player);
             } catch (Exception ex) {
-                player.sendMessage(color("&cNie udało się rozpocząć instancji: " + ex.getMessage()));
+                player.sendMessage(color("&cFailed to start the instance: " + ex.getMessage()));
                 ex.printStackTrace();
             }
         });

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
@@ -109,12 +109,12 @@ public class BloodChestSession {
         teleportPlayerToArena();
         this.startTimeMillis = System.currentTimeMillis();
         spawnMobs(world);
-        player.sendMessage(color("&7Pokonaj wszystkie &cKrwiste Błotniaki &7jak najszybciej!"));
+        player.sendMessage(color("&7Defeat all &cBlood Sludges &7as quickly as possible!"));
     }
 
     private void ensureSchematicExists() throws IOException {
         if (!schematicFile.exists()) {
-            throw new IOException("Nie znaleziono schematu areny: " + schematicFile.getAbsolutePath());
+            throw new IOException("Arena schematic not found: " + schematicFile.getAbsolutePath());
         }
     }
 
@@ -265,7 +265,7 @@ public class BloodChestSession {
     private void onMobsDefeated() {
         long elapsedSeconds = (System.currentTimeMillis() - startTimeMillis) / 1000L;
         int chestCount = determineChestCount((int) elapsedSeconds);
-        player.sendMessage(color("&7Wszystkie błotniaki zostały pokonane w &e" + elapsedSeconds + "s&7!"));
+        player.sendMessage(color("&7All sludges were defeated in &e" + elapsedSeconds + "s&7!"));
         spawnChests(chestCount);
     }
 
@@ -295,7 +295,7 @@ public class BloodChestSession {
             }
             spawnedChests.put(location, Boolean.FALSE);
         }
-        player.sendMessage(color("&cPojawiły się " + available + " Krwawe Skrzynie!"));
+        player.sendMessage(color("&c" + available + " Blood Chests have appeared!"));
     }
 
     public boolean handleChestInteraction(Player clicker, Block block) {
@@ -312,7 +312,7 @@ public class BloodChestSession {
         LootResult result = lootService.generateLoot(player.getUniqueId(), rewardSettings.getRollsPerChest(), pityManager);
         dropItems(location, result);
         if (result.isPityGranted()) {
-            player.sendMessage(color("&6Pity drop został przyznany!"));
+            player.sendMessage(color("&6A pity drop has been granted!"));
         }
         if (spawnedChests.values().stream().allMatch(Boolean::booleanValue)) {
             startExitCountdown();
@@ -360,7 +360,7 @@ public class BloodChestSession {
                     finishSession();
                     return;
                 }
-                Title title = Title.title(Component.text(ChatColor.RED + "Powrót za"),
+                Title title = Title.title(Component.text(ChatColor.RED + "Returning in"),
                         Component.text(ChatColor.GOLD + String.valueOf(remaining) + ChatColor.GRAY + " s"),
                         Title.Times.times(Duration.ZERO, Duration.ofSeconds(1), Duration.ZERO));
                 player.showTitle(title);
@@ -368,7 +368,7 @@ public class BloodChestSession {
             }
         };
         exitCountdownTask.runTaskTimer(plugin, 0L, 20L);
-        player.sendMessage(color("&7Zostaniesz przeniesiony za &e" + exitCountdownSeconds + "s"));
+        player.sendMessage(color("&7You will be teleported in &e" + exitCountdownSeconds + "s"));
     }
 
     private void finishSession() {
@@ -382,7 +382,7 @@ public class BloodChestSession {
         }
         if (player.isOnline()) {
             player.teleport(returnLocation);
-            player.sendMessage(color("&7Zakończono wyzwanie Blood Chest."));
+            player.sendMessage(color("&7The Blood Chest challenge has ended."));
         }
         if (pasteOrigin != null && pasteOrigin.getWorld() != null) {
             schematicHandler.clearRegion(pasteOrigin.getWorld(), pasteOrigin, arenaSettings.getRegionSize());

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
@@ -67,7 +67,7 @@ public class SessionManager {
             throw new IllegalStateException("Player already has an active blood chest session");
         }
         ArenaSlotInstance slot = slots.stream().filter(s -> !s.isBusy()).findFirst()
-                .orElseThrow(() -> new IllegalStateException("Brak dostępnych instancji areny. Spróbuj ponownie później."));
+                .orElseThrow(() -> new IllegalStateException("No arena instances are available. Please try again later."));
         slot.setBusy(true);
         BloodChestSession session = new BloodChestSession(plugin, configuration, schematicHandler, lootService, pityManager,
                 slot, returnLocation, schematicFile, this);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,34 +3,34 @@ permission: bloodchest.use
 gui:
   title: "&8Blood Chest"
   instructions:
-    - "&7Wejdź solo na arenę i pokonaj &c5 Krwistych Błotniaków&7."
-    - "&7Im szybciej zwyciężysz, tym więcej skrzyń się pojawi."
-    - "&7Każde wejście kosztuje &c25 Fragment of Infernal Passage&7."
+    - "&7Enter the arena solo and defeat &c5 Blood Sludges&7."
+    - "&7The faster you win, the more chests will appear."
+    - "&7Each entry costs &c25 Fragment of Infernal Passage&7."
   start-button:
     slot: 13
     material: NETHER_STAR
-    name: "&cRozpocznij Blood Chest"
+    name: "&cStart Blood Chest"
     lore:
-      - "&7Rozpocznij nowe wyzwanie."
-      - "&7Koszt: &c25 Fragment of Infernal Passage"
+      - "&7Begin a new challenge."
+      - "&7Cost: &c25 Fragment of Infernal Passage"
   loot-button:
     slot: 15
     material: CHEST
-    name: "&6Zobacz nagrody"
+    name: "&6View Rewards"
     lore:
-      - "&7Wyświetl możliwe łupy."
+      - "&7Display the possible loot."
   close-button:
     slot: 26
     material: BARRIER
-    name: "&cZamknij"
+    name: "&cClose"
     lore:
-      - "&7Zamknij to menu."
+      - "&7Close this menu."
   back-button:
     slot: 45
     material: ARROW
-    name: "&ePowrót"
+    name: "&eBack"
     lore:
-      - "&7Wróć do poprzedniego ekranu."
+      - "&7Return to the previous screen."
 
 key:
   material: IRON_NUGGET
@@ -103,7 +103,7 @@ arena:
     material: CHEST
     name: "&4Blood Chest"
     lore:
-      - "&7Otwórz, aby odebrać nagrody."
+      - "&7Open to claim your rewards."
   mob:
     spawn-mode: MYTHIC_COMMAND
     mythic-id: blood_sludge


### PR DESCRIPTION
## Summary
- translate configuration entries and menu labels to English for Blood Chest
- update runtime messages and defaults to English across commands and sessions

## Testing
- `mvn -q -DskipTests package` *(fails: missing WorldEdit classes)*

------
https://chatgpt.com/codex/tasks/task_e_68d6768752c4832ab5655955b836762e