### PR TITLE
Support slot-area configuration and expanded mob spawning

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/PluginConfiguration.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/PluginConfiguration.java
@@ -340,19 +340,25 @@ public class PluginConfiguration {
         private final String metadataKey;
         private final EntityType fallbackEntityType;
         private final int spawnYOffset;
+        private final int primaryMobCount;
+        private final List<String> additionalMythicMobIds;
 
         public MobSettings(SpawnMode spawnMode,
                            String mythicMobId,
                            String spawnCommand,
                            String metadataKey,
                            EntityType fallbackEntityType,
-                           int spawnYOffset) {
+                           int spawnYOffset,
+                           int primaryMobCount,
+                           List<String> additionalMythicMobIds) {
             this.spawnMode = Objects.requireNonNull(spawnMode, "spawnMode");
             this.mythicMobId = mythicMobId;
             this.spawnCommand = spawnCommand;
             this.metadataKey = metadataKey;
             this.fallbackEntityType = fallbackEntityType == null ? EntityType.ZOMBIE : fallbackEntityType;
             this.spawnYOffset = spawnYOffset;
+            this.primaryMobCount = Math.max(1, primaryMobCount);
+            this.additionalMythicMobIds = List.copyOf(additionalMythicMobIds);
         }
 
         public SpawnMode getSpawnMode() {
@@ -377,6 +383,14 @@ public class PluginConfiguration {
 
         public int getSpawnYOffset() {
             return spawnYOffset;
+        }
+
+        public int getPrimaryMobCount() {
+            return primaryMobCount;
+        }
+
+        public List<String> getAdditionalMythicMobIds() {
+            return additionalMythicMobIds;
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -107,17 +107,23 @@ arena:
   mob:
     spawn-mode: MYTHIC_COMMAND
     mythic-id: blood_sludge
+    primary-count: 5
+    additional-mythic-ids:
+      - blood_leech
+      - blood_sludgeling
     spawn-command: "mm mobs spawn {id} {world} {x} {y} {z}"
     metadata-key: MythicMob
     fallback-entity: HUSK
     y-offset: 1
-  slots:
-    slot-1:
-      origin:
-        world: world
-        x: 0
-        y: 80
-        z: 0
+  slot-area:
+    min:
+      x: 794
+      y: -61
+      z: -2365
+    max:
+      x: 1165
+      y: 33
+      z: -1874
 
 rewards:
   exit-countdown-seconds: 60


### PR DESCRIPTION
## Summary
- add support for configuring an arena slot rectangle that expands into multiple slot origins
- extend mob settings with configurable primary counts and additional MythicMob IDs
- update session logic to spawn, track, and clean up primary and auxiliary mobs using the new settings

## Testing
- `mvn -q -DskipTests package` *(fails: missing WorldEdit edit package in provided dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a005d914832abdc22fcb8e5543b7