### PR TITLE
Derive player spawn from schematic marker

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
@@ -72,8 +72,14 @@ public class SessionManager {
         BloodChestSession session = new BloodChestSession(plugin, configuration, schematicHandler, lootService, pityManager,
                 slot, returnLocation, schematicFile, this);
         sessions.put(player.getUniqueId(), session);
-        session.start(player);
-        return session;
+        try {
+            session.start(player);
+            return session;
+        } catch (Exception ex) {
+            sessions.remove(player.getUniqueId());
+            slot.setBusy(false);
+            throw ex;
+        }
     }
 
     public synchronized void endSession(BloodChestSession session) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -85,6 +85,7 @@ arena:
     x: 0.5
     y: 1.0
     z: 0.5
+  # Na schemacie złoty blok wyznacza miejsce, w którym ma pojawić się gracz.
   paste-offset:
     x: 0
     y: 0


### PR DESCRIPTION
## Summary
- detect the gold block marker in the arena schematic and teleport players above it
- abort session start when the schematic lacks chest spawn markers or a player spawn marker
- ensure arena slots are released if session initialization fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6c390900832a8a5e783cb9d727fb