### PR TITLE
Auto-detect schematic region size from pasted schematics

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
@@ -8,7 +8,21 @@ import java.io.File;
 
 public interface SchematicHandler {
 
-    void pasteSchematic(File schematicFile, World world, Location origin) throws Exception;
+    PasteResult pasteSchematic(File schematicFile, World world, Location origin) throws Exception;
 
     void clearRegion(World world, Location origin, Vector size);
+
+    record PasteResult(Vector regionSize) {
+
+        public PasteResult {
+            if (regionSize != null) {
+                regionSize = regionSize.clone();
+            }
+        }
+
+        @Override
+        public Vector regionSize() {
+            return regionSize == null ? null : regionSize.clone();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- capture the pasted schematic dimensions when pasting arenas and expose them through the schematic handler
- expand marker scanning, arena bounds checks, and cleanup logic to use the resolved schematic size
- log when the schematic forces the scan region to grow so oversized arenas continue to work without config tweaks

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68db907ea424832a90de64a251abf5d9