### PR TITLE
Resolve marker detection directly from schematics

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
@@ -1,18 +1,49 @@
 package pl.yourserver.bloodChestPlugin.session;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.util.Vector;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public interface SchematicHandler {
 
-    PasteResult pasteSchematic(File schematicFile, World world, Location origin) throws Exception;
+    PasteResult pasteSchematic(File schematicFile,
+                               World world,
+                               Location origin,
+                               MarkerConfiguration markerConfiguration) throws Exception;
 
     void clearRegion(World world, Location origin, Vector size);
 
-    record PasteResult(Vector minimumOffset, Vector maximumOffset, Vector regionSize) {
+    record MarkerConfiguration(Material mobMarker,
+                               Material chestMarker,
+                               Optional<Material> minorMobMarker) {
+
+        public MarkerConfiguration {
+            Objects.requireNonNull(mobMarker, "mobMarker");
+            Objects.requireNonNull(chestMarker, "chestMarker");
+            minorMobMarker = minorMobMarker == null ? Optional.empty() : minorMobMarker;
+        }
+    }
+
+    record BlockOffset(int x, int y, int z) {
+        public BlockOffset {
+            // No validation needed; values originate from schematic coordinates.
+        }
+    }
+
+    record PasteResult(Vector minimumOffset,
+                       Vector maximumOffset,
+                       Vector regionSize,
+                       List<BlockOffset> mobMarkerOffsets,
+                       List<BlockOffset> chestMarkerOffsets,
+                       List<BlockOffset> minorMobMarkerOffsets,
+                       List<BlockOffset> playerSpawnMarkerOffsets) {
 
         public PasteResult {
             if (minimumOffset != null) {
@@ -24,6 +55,18 @@ public interface SchematicHandler {
             if (regionSize != null) {
                 regionSize = regionSize.clone();
             }
+            mobMarkerOffsets = mobMarkerOffsets == null
+                    ? List.of()
+                    : List.copyOf(mobMarkerOffsets);
+            chestMarkerOffsets = chestMarkerOffsets == null
+                    ? List.of()
+                    : List.copyOf(chestMarkerOffsets);
+            minorMobMarkerOffsets = minorMobMarkerOffsets == null
+                    ? List.of()
+                    : List.copyOf(minorMobMarkerOffsets);
+            playerSpawnMarkerOffsets = playerSpawnMarkerOffsets == null
+                    ? List.of()
+                    : List.copyOf(playerSpawnMarkerOffsets);
         }
 
         @Override
@@ -39,6 +82,26 @@ public interface SchematicHandler {
         @Override
         public Vector regionSize() {
             return regionSize == null ? null : regionSize.clone();
+        }
+
+        @Override
+        public List<BlockOffset> mobMarkerOffsets() {
+            return Collections.unmodifiableList(mobMarkerOffsets);
+        }
+
+        @Override
+        public List<BlockOffset> chestMarkerOffsets() {
+            return Collections.unmodifiableList(chestMarkerOffsets);
+        }
+
+        @Override
+        public List<BlockOffset> minorMobMarkerOffsets() {
+            return Collections.unmodifiableList(minorMobMarkerOffsets);
+        }
+
+        @Override
+        public List<BlockOffset> playerSpawnMarkerOffsets() {
+            return Collections.unmodifiableList(playerSpawnMarkerOffsets);
         }
     }
 }

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/WorldEditSchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/WorldEditSchematicHandler.java
@@ -13,19 +13,29 @@ import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.session.ClipboardHolder;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 public class WorldEditSchematicHandler implements SchematicHandler {
 
     @Override
-    public PasteResult pasteSchematic(File schematicFile, World world, Location origin) throws IOException {
+    public PasteResult pasteSchematic(File schematicFile,
+                                      World world,
+                                      Location origin,
+                                      MarkerConfiguration markerConfiguration) throws IOException {
         ClipboardFormat format = ClipboardFormats.findByFile(schematicFile);
         if (format == null) {
             throw new IOException("Unsupported schematic format for file " + schematicFile.getAbsolutePath());
@@ -54,7 +64,14 @@ public class WorldEditSchematicHandler implements SchematicHandler {
         Vector maximumOffset = toBukkitVector(max.subtract(clipboardOrigin));
         BlockVector3 dimensions = clipboard.getDimensions();
         Vector regionSize = new Vector(dimensions.getBlockX(), dimensions.getBlockY(), dimensions.getBlockZ());
-        return new PasteResult(minimumOffset, maximumOffset, regionSize);
+        MarkerScan scan = scanMarkers(clipboard, markerConfiguration);
+        return new PasteResult(minimumOffset,
+                maximumOffset,
+                regionSize,
+                scan.mobMarkerOffsets(),
+                scan.chestMarkerOffsets(),
+                scan.minorMobMarkerOffsets(),
+                scan.playerSpawnOffsets());
     }
 
     @Override
@@ -92,5 +109,68 @@ public class WorldEditSchematicHandler implements SchematicHandler {
         } catch (ReflectiveOperationException ignored) {
             // No-op when the method is unavailable (vanilla WorldEdit).
         }
+    }
+
+    private MarkerScan scanMarkers(Clipboard clipboard, MarkerConfiguration markerConfiguration) {
+        List<BlockOffset> mobOffsets = new ArrayList<>();
+        List<BlockOffset> chestOffsets = new ArrayList<>();
+        List<BlockOffset> minorOffsets = new ArrayList<>();
+        List<BlockOffset> playerSpawnOffsets = new ArrayList<>();
+
+        String mobMarkerId = materialId(markerConfiguration.mobMarker());
+        String chestMarkerId = materialId(markerConfiguration.chestMarker());
+        Optional<String> minorMarkerId = markerConfiguration.minorMobMarker()
+                .map(this::materialId);
+        String playerSpawnId = materialId(Material.GOLD_BLOCK);
+
+        BlockVector3 origin = clipboard.getOrigin();
+        for (BlockVector3 position : clipboard.getRegion()) {
+            BlockStateHolder<?> state = clipboard.getFullBlock(position);
+            String stateId = state.getBlockType().getId();
+            if (matches(stateId, mobMarkerId)) {
+                mobOffsets.add(toOffset(position.subtract(origin)));
+                continue;
+            }
+            if (matches(stateId, chestMarkerId)) {
+                chestOffsets.add(toOffset(position.subtract(origin)));
+                continue;
+            }
+            if (minorMarkerId.isPresent() && matches(stateId, minorMarkerId.get())) {
+                minorOffsets.add(toOffset(position.subtract(origin)));
+                continue;
+            }
+            if (matches(stateId, playerSpawnId)) {
+                playerSpawnOffsets.add(toOffset(position.subtract(origin)));
+            }
+        }
+
+        return new MarkerScan(mobOffsets, chestOffsets, minorOffsets, playerSpawnOffsets);
+    }
+
+    private String materialId(Material material) {
+        NamespacedKey key = material.getKey();
+        return key.getNamespace().toLowerCase(Locale.ROOT) + ":" + key.getKey().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean matches(String stateId, String targetId) {
+        if (stateId.equalsIgnoreCase(targetId)) {
+            return true;
+        }
+        int separatorIndex = targetId.indexOf(':');
+        if (separatorIndex >= 0) {
+            String withoutNamespace = targetId.substring(separatorIndex + 1);
+            return stateId.equalsIgnoreCase(withoutNamespace);
+        }
+        return false;
+    }
+
+    private BlockOffset toOffset(BlockVector3 vector) {
+        return new BlockOffset(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+    }
+
+    private record MarkerScan(List<BlockOffset> mobMarkerOffsets,
+                              List<BlockOffset> chestMarkerOffsets,
+                              List<BlockOffset> minorMobMarkerOffsets,
+                              List<BlockOffset> playerSpawnOffsets) {
     }
 }


### PR DESCRIPTION
## Summary
- capture mob, chest, minor-mob, and player spawn marker offsets directly from the schematic during paste
- use the schematic-provided markers when initializing a session and fall back to world scanning only when necessary
- add helpers for working with schematic marker offsets relative to the paste origin

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dba50909d0832aba143e2f5929a4d0