### PR TITLE
Fix Mythic spawn command formatting and adjust schematic height

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
@@ -176,7 +176,7 @@ public class ConfigurationLoader {
         }
 
         String mythicId = section.getString("mythic-id");
-        String command = section.getString("spawn-command", "mm mobs spawn {id} {world} {x} {y} {z}");
+        String command = section.getString("spawn-command", "mm mobs spawn {id} {location}");
         String metadataKey = section.getString("metadata-key", "MythicMob");
         EntityType fallbackEntity = ConfigUtil.readEntityType(section.getString("fallback-entity"), EntityType.HUSK);
         int spawnYOffset = section.getInt("y-offset", 1);

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SchematicHandler.java
@@ -40,6 +40,7 @@ public interface SchematicHandler {
     record PasteResult(Vector minimumOffset,
                        Vector maximumOffset,
                        Vector regionSize,
+                       Vector appliedOffset,
                        List<BlockOffset> mobMarkerOffsets,
                        List<BlockOffset> chestMarkerOffsets,
                        List<BlockOffset> minorMobMarkerOffsets,
@@ -54,6 +55,9 @@ public interface SchematicHandler {
             }
             if (regionSize != null) {
                 regionSize = regionSize.clone();
+            }
+            if (appliedOffset != null) {
+                appliedOffset = appliedOffset.clone();
             }
             mobMarkerOffsets = mobMarkerOffsets == null
                     ? List.of()
@@ -82,6 +86,11 @@ public interface SchematicHandler {
         @Override
         public Vector regionSize() {
             return regionSize == null ? null : regionSize.clone();
+        }
+
+        @Override
+        public Vector appliedOffset() {
+            return appliedOffset == null ? null : appliedOffset.clone();
         }
 
         @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -97,7 +97,7 @@ arena:
   mob:
     spawn-mode: MYTHIC_COMMAND
     mythic-id: blood_sludge
-    spawn-command: "mm mobs spawn {id} {world}, {x}, {y}, {z}"
+    spawn-command: "mm mobs spawn {id} {location}"
     metadata-key: MythicMob
     fallback-entity: HUSK
     y-offset: 1


### PR DESCRIPTION
## Summary
- ensure schematic pastes are vertically adjusted so the arena no longer drops below the world floor while exposing the applied offset
- update Mythic spawn command construction to emit the required world,x,y,z,yaw,pitch string and support legacy placeholder patterns
- refresh the default configuration to use the new {location} placeholder for Mythic spawn commands

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbaee5ce54832ab0720445ed397141