### PR TITLE
Align MythicMobs spawn command with Mythic expectations

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/config/ConfigurationLoader.java
@@ -176,7 +176,7 @@ public class ConfigurationLoader {
         }
 
         String mythicId = section.getString("mythic-id");
-        String command = section.getString("spawn-command", "mm mobs spawn {id} {location}");
+        String command = section.getString("spawn-command", "mm m spawn {id} {amount} {location}");
         String metadataKey = section.getString("metadata-key", "MythicMob");
         EntityType fallbackEntity = ConfigUtil.readEntityType(section.getString("fallback-entity"), EntityType.HUSK);
         int spawnYOffset = section.getInt("y-offset", 1);

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
@@ -456,7 +456,7 @@ public class BloodChestSession {
     private String buildSpawnCommand(String mobId, MobSettings mobSettings, Location location) {
         String command = mobSettings.getSpawnCommand();
         if (command == null || command.isBlank()) {
-            command = "mm mobs spawn {id} {location}";
+            command = "mm m spawn {id} {amount} {location}";
         }
         World world = location.getWorld();
         if (world == null) {
@@ -469,10 +469,16 @@ public class BloodChestSession {
         String z = formatCoordinate(location.getZ());
         String yaw = formatCoordinate(location.getYaw());
         String pitch = formatCoordinate(location.getPitch());
-        String locationToken = String.join(",", worldName, x, y, z, yaw, pitch);
+        String amount = "1";
+        String locationToken = String.join(",", worldName, x, y, z);
+        String locationSpaceToken = String.join(" ", worldName, x, y, z);
+        String locationWithAnglesToken = String.join(" ", worldName, x, y, z, yaw, pitch);
         command = LEGACY_LOCATION_PATTERN.matcher(command).replaceAll("{location}");
         return command
+                .replace("{location_with_yaw_pitch}", locationWithAnglesToken)
+                .replace("{location_space}", locationSpaceToken)
                 .replace("{location}", locationToken)
+                .replace("{amount}", amount)
                 .replace("{id}", id)
                 .replace("{world}", worldName)
                 .replace("{x}", x)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -97,7 +97,7 @@ arena:
   mob:
     spawn-mode: MYTHIC_COMMAND
     mythic-id: blood_sludge
-    spawn-command: "mm mobs spawn {id} {location}"
+    spawn-command: "mm m spawn {id} {amount} {location}"
     metadata-key: MythicMob
     fallback-entity: HUSK
     y-offset: 1


### PR DESCRIPTION
## Summary
- build MythicMobs spawn commands with comma-delimited location tokens and an amount placeholder so the world resolves correctly
- update the default configuration and loader defaults to use the corrected Mythic command syntax

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbb2c15938832a906a1f62396014e6