### PR TITLE
Add MythicMobs integration for blood chest sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <id>enginehub-repo</id>
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
+        <repository>
+            <id>mythiccraft-repo</id>
+            <url>https://mvn.mythiccraft.io/artifactory/repository/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -78,6 +82,12 @@
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.2.15</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-Dist</artifactId>
+            <version>5.5.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/pl/yourserver/bloodChestPlugin/BloodChestPlugin.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/BloodChestPlugin.java
@@ -1,6 +1,7 @@
 package pl.yourserver.bloodChestPlugin;
 
 import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import pl.yourserver.bloodChestPlugin.command.BloodChestCommand;
 import pl.yourserver.bloodChestPlugin.config.ConfigurationLoader;
@@ -14,6 +15,7 @@ import pl.yourserver.bloodChestPlugin.session.PityManager;
 import pl.yourserver.bloodChestPlugin.session.SessionListener;
 import pl.yourserver.bloodChestPlugin.session.SessionManager;
 import pl.yourserver.bloodChestPlugin.session.WorldEditSchematicHandler;
+import pl.yourserver.bloodChestPlugin.session.MythicSessionListener;
 
 import java.io.File;
 
@@ -54,6 +56,13 @@ public final class BloodChestPlugin extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(menuManager, this);
         getServer().getPluginManager().registerEvents(new SessionListener(sessionManager), this);
+
+        Plugin mythicMobs = getServer().getPluginManager().getPlugin("MythicMobs");
+        if (mythicMobs != null && mythicMobs.isEnabled()) {
+            getServer().getPluginManager().registerEvents(new MythicSessionListener(sessionManager), this);
+        } else {
+            getLogger().warning("MythicMobs plugin not found or disabled. Mythic mob support will be limited.");
+        }
 
         PluginCommand command = getCommand("blood_chest");
         if (command != null) {

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
@@ -1,0 +1,32 @@
+package pl.yourserver.bloodChestPlugin.session;
+
+import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
+import io.lumine.mythic.bukkit.events.MythicMobSpawnEvent;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class MythicSessionListener implements Listener {
+
+    private final SessionManager sessionManager;
+
+    public MythicSessionListener(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    @EventHandler
+    public void onMythicMobSpawn(MythicMobSpawnEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (entity != null) {
+            sessionManager.handleEntitySpawn(entity);
+        }
+    }
+
+    @EventHandler
+    public void onMythicMobDeath(MythicMobDeathEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (entity != null) {
+            sessionManager.handleEntityDeath(entity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MythicMobs spawn and death listeners so session mob tracking works with Mythic mobs
- register the listener only when MythicMobs is available and add the MythicMobs distribution as a provided dependency

## Testing
- `mvn -DskipTests package` *(fails: https://mvn.mythiccraft.io/artifactory/repository/public/ returned 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dbca9c4d78832abb90eb3dfb5e1c98