### PR TITLE
Fix Mythic session listener entity handling

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
@@ -16,17 +16,15 @@ public class MythicSessionListener implements Listener {
 
     @EventHandler
     public void onMythicMobSpawn(MythicMobSpawnEvent event) {
-        LivingEntity entity = event.getEntity();
-        if (entity != null) {
-            sessionManager.handleEntitySpawn(entity);
+        if (event.getEntity() instanceof LivingEntity livingEntity) {
+            sessionManager.handleEntitySpawn(livingEntity);
         }
     }
 
     @EventHandler
     public void onMythicMobDeath(MythicMobDeathEvent event) {
-        LivingEntity entity = event.getEntity();
-        if (entity != null) {
-            sessionManager.handleEntityDeath(entity);
+        if (event.getEntity() instanceof LivingEntity livingEntity) {
+            sessionManager.handleEntityDeath(livingEntity);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Mythic mob spawn and death handlers only process living entities

## Testing
- mvn -q -e -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dbccfefd74832aac3d6a1585158de0