### PR TITLE
Improve Mythic mob tracking and progress detection

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
@@ -16,17 +16,24 @@ public class MythicSessionListener implements Listener {
 
     @EventHandler
     public void onMythicMobSpawn(MythicMobSpawnEvent event) {
-        LivingEntity entity = event.getEntity();
-        if (entity != null) {
-            sessionManager.handleEntitySpawn(entity);
+        LivingEntity livingEntity = event.getLivingEntity();
+        if (livingEntity == null) {
+            return;
         }
+        String internalName = event.getMobType() != null
+                ? event.getMobType().getInternalName()
+                : null;
+        sessionManager.handleMythicMobSpawn(livingEntity, internalName);
     }
 
     @EventHandler
     public void onMythicMobDeath(MythicMobDeathEvent event) {
-        LivingEntity entity = event.getEntity();
-        if (entity != null) {
-            sessionManager.handleEntityDeath(entity);
+        if (!(event.getEntity() instanceof LivingEntity livingEntity)) {
+            return;
         }
+        String internalName = event.getMobType() != null
+                ? event.getMobType().getInternalName()
+                : null;
+        sessionManager.handleMythicMobDeath(livingEntity, internalName);
     }
 }

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionListener.java
@@ -1,8 +1,8 @@
 package pl.yourserver.bloodChestPlugin.session;
 
 import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -39,12 +39,14 @@ public class SessionListener implements Listener {
 
     @EventHandler
     public void onEntityDeath(EntityDeathEvent event) {
-        sessionManager.handleEntityDeath(event.getEntity());
+        LivingEntity entity = event.getEntity();
+        sessionManager.handleEntityDeath(entity);
     }
 
     @EventHandler
     public void onCreatureSpawn(CreatureSpawnEvent event) {
-        sessionManager.handleEntitySpawn(event.getEntity());
+        LivingEntity entity = event.getEntity();
+        sessionManager.handleEntitySpawn(entity);
     }
 
     @EventHandler

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
@@ -3,8 +3,8 @@ package pl.yourserver.bloodChestPlugin.session;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.Plugin;
 import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
 import pl.yourserver.bloodChestPlugin.config.PluginConfiguration.ArenaSettings;
@@ -100,15 +100,27 @@ public class SessionManager {
         return false;
     }
 
-    public void handleEntityDeath(Entity entity) {
+    public void handleEntityDeath(LivingEntity entity) {
         for (BloodChestSession session : sessions.values()) {
-            session.handleEntityDeath(entity);
+            session.handleEntityDeath(entity, null);
         }
     }
 
-    public void handleEntitySpawn(Entity entity) {
+    public void handleEntitySpawn(LivingEntity entity) {
         for (BloodChestSession session : sessions.values()) {
-            session.handleEntitySpawn(entity);
+            session.handleEntitySpawn(entity, null);
+        }
+    }
+
+    public void handleMythicMobSpawn(LivingEntity entity, String mythicMobName) {
+        for (BloodChestSession session : sessions.values()) {
+            session.handleEntitySpawn(entity, mythicMobName);
+        }
+    }
+
+    public void handleMythicMobDeath(LivingEntity entity, String mythicMobName) {
+        for (BloodChestSession session : sessions.values()) {
+            session.handleEntityDeath(entity, mythicMobName);
         }
     }
 


### PR DESCRIPTION
## Summary
- pass Mythic mob internal names into session handling and resolve them via MythicMobs API
- tag spawned mobs consistently and distinguish primary versus additional mobs for progress updates
- update session listeners to work with living entities and Mythic-specific spawn/death events

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dbccfefd74832aac3d6a1585158de0