### PR TITLE
Handle MythicMobs events for blood chest spawns

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/MythicSessionListener.java
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener;
 public class MythicSessionListener implements Listener {
 
     private final SessionManager sessionManager;
+    private static final String PRIMARY_MYTHIC_ID = "blood_sludge";
 
     public MythicSessionListener(SessionManager sessionManager) {
         this.sessionManager = sessionManager;
@@ -23,6 +24,9 @@ public class MythicSessionListener implements Listener {
         String internalName = event.getMobType() != null
                 ? event.getMobType().getInternalName()
                 : null;
+        if (internalName != null && internalName.equalsIgnoreCase(PRIMARY_MYTHIC_ID)) {
+            livingEntity.addScoreboardTag(BloodChestSession.PRIMARY_MOB_TAG);
+        }
         sessionManager.handleMythicMobSpawn(livingEntity, internalName);
     }
 


### PR DESCRIPTION
## Summary
- tag spawned Blood Sludges as blood chest primaries via MythicMobSpawnEvent and keep forwarding Mythic mob details to the session manager
- use Mythic event metadata to track arena mobs without relying on exact spawn locations, exposing shared scoreboard tags for reuse

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbe2512eb4832aa8988372201805af