### PR TITLE
Improve chest handling and minor mob spawns

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
@@ -2,6 +2,7 @@ package pl.yourserver.bloodChestPlugin.util;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -56,6 +57,7 @@ public final class ItemStackUtil {
         if (input == null) {
             return Component.empty();
         }
-        return SERIALIZER.deserialize(input.replace("§", "&"));
+        Component component = SERIALIZER.deserialize(input.replace("§", "&"));
+        return component.decoration(TextDecoration.ITALIC, false);
     }
 }


### PR DESCRIPTION
## Summary
- clear schematic chest markers after paste and leave opened reward chests visible instead of removing the block
- adjust minor mob spawn logic to find reliable ground positions above configured DIRT markers
- translate the boss bar victory message to English and ensure loot item display names keep their configured styling without italics

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbf5930b0c832ab2cf9fdd0b5a8850