### PR TITLE
Improve minor mob diagnostics and countdown boss bar

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
@@ -2,6 +2,8 @@ package pl.yourserver.bloodChestPlugin.util;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextDecoration.State;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -56,6 +58,7 @@ public final class ItemStackUtil {
         if (input == null) {
             return Component.empty();
         }
-        return SERIALIZER.deserialize(input.replace("§", "&"));
+        Component component = SERIALIZER.deserialize(input.replace("§", "&"));
+        return component.decorationIfAbsent(TextDecoration.ITALIC, State.FALSE);
     }
 }


### PR DESCRIPTION
## Summary
- preserve configured italics in loot lore while removing implicit italics from reward display names
- show the exit countdown on the boss bar and clean up countdown state handling
- refine minor mob spawn resolution and add logging plus delayed checks to diagnose missing spawns

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbf5930b0c832ab2cf9fdd0b5a8850