### PR TITLE
Fix minor spawn command and retain chest visuals

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootItemDefinition.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/loot/LootItemDefinition.java
@@ -1,10 +1,12 @@
 package pl.yourserver.bloodChestPlugin.loot;
 
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 public class LootItemDefinition {
 
@@ -18,6 +20,10 @@ public class LootItemDefinition {
     private final double weight;
     private final int rolls;
     private final double pityWeight;
+    private final boolean hideFlags;
+    private final boolean hideAttributes;
+    private final boolean unbreakable;
+    private final Map<Enchantment, Integer> enchantments;
 
     public LootItemDefinition(String id,
                               Material material,
@@ -28,7 +34,11 @@ public class LootItemDefinition {
                               int maxAmount,
                               double weight,
                               int rolls,
-                              double pityWeight) {
+                              double pityWeight,
+                              boolean hideFlags,
+                              boolean hideAttributes,
+                              boolean unbreakable,
+                              Map<Enchantment, Integer> enchantments) {
         this.id = Objects.requireNonNull(id, "id");
         this.material = Objects.requireNonNull(material, "material");
         this.displayName = Objects.requireNonNull(displayName, "displayName");
@@ -39,6 +49,12 @@ public class LootItemDefinition {
         this.weight = weight;
         this.rolls = Math.max(1, rolls);
         this.pityWeight = pityWeight;
+        this.hideFlags = hideFlags;
+        this.hideAttributes = hideAttributes;
+        this.unbreakable = unbreakable;
+        this.enchantments = enchantments == null || enchantments.isEmpty()
+                ? Map.of()
+                : Map.copyOf(enchantments);
     }
 
     public String getId() {
@@ -79,5 +95,21 @@ public class LootItemDefinition {
 
     public double getPityWeight() {
         return pityWeight;
+    }
+
+    public boolean isHideFlags() {
+        return hideFlags;
+    }
+
+    public boolean isHideAttributes() {
+        return hideAttributes;
+    }
+
+    public boolean isUnbreakable() {
+        return unbreakable;
+    }
+
+    public Map<Enchantment, Integer> getEnchantments() {
+        return enchantments;
     }
 }

--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/BloodChestSession.java
@@ -3,7 +3,6 @@ package pl.yourserver.bloodChestPlugin.session;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import io.lumine.mythic.core.mobs.ActiveMob;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.title.Title;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -11,6 +10,8 @@ import org.bukkit.Material;
 import org.bukkit.Nameable;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Lidded;
 import org.bukkit.block.TileState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -21,6 +22,7 @@ import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 import org.bukkit.metadata.MetadataValue;
 import pl.yourserver.bloodChestPlugin.config.PluginConfiguration;
@@ -36,7 +38,6 @@ import pl.yourserver.bloodChestPlugin.session.PityManager;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,6 +79,7 @@ public class BloodChestSession {
     private final List<Location> chestLocations = new ArrayList<>();
     private final Map<Location, Boolean> spawnedChests = new HashMap<>();
     private final Map<Location, List<Component>> chestLoreByLocation = new HashMap<>();
+    private final Map<Location, BukkitTask> chestOpenTasks = new HashMap<>();
     private final Map<UUID, SpawnType> activeMobs = new HashMap<>();
     private final Set<UUID> processedDeaths = new HashSet<>();
     private final List<SpawnAssignment> pendingSpawnAssignments = new ArrayList<>();
@@ -91,7 +93,7 @@ public class BloodChestSession {
     private boolean mobsDefeated;
     private boolean finished;
     private BukkitRunnable exitCountdownTask;
-    private int exitCountdownSeconds;
+    private int exitCountdownTotalSeconds;
     private BossBar progressBar;
     private BukkitRunnable bossBarTask;
 
@@ -174,6 +176,7 @@ public class BloodChestSession {
                 minorMobSpawnLocations.clear();
                 chestLocations.clear();
                 spawnedChests.clear();
+                stopChestOpenTasks();
                 chestLoreByLocation.clear();
                 activeMobs.clear();
                 pendingSpawnAssignments.clear();
@@ -238,12 +241,13 @@ public class BloodChestSession {
             mobSpawnLocations.add(spawnLocation);
         }
         for (SchematicHandler.BlockOffset offset : pasteResult.chestMarkerOffsets()) {
-            chestLocations.add(toWorldBlockLocation(offset));
+            Location blockLocation = toWorldBlockLocation(offset).toBlockLocation();
+            chestLocations.add(blockLocation.clone());
+            clearMarkerBlock(blockLocation);
         }
         for (SchematicHandler.BlockOffset offset : pasteResult.minorMobMarkerOffsets()) {
             Location blockLocation = toWorldBlockLocation(offset);
-            Location spawnLocation = blockLocation.add(0.5, 1.0, 0.5);
-            minorMobSpawnLocations.add(spawnLocation);
+            minorMobSpawnLocations.add(blockLocation.clone());
         }
 
         boolean spawnMarkerFound = false;
@@ -287,10 +291,12 @@ public class BloodChestSession {
                         Location spawnLocation = block.getLocation().add(0.5, 1.0, 0.5);
                         mobSpawnLocations.add(spawnLocation);
                     } else if (scanChestMarkers && block.getType() == arenaSettings.getChestMarkerMaterial()) {
-                        chestLocations.add(block.getLocation());
+                        Location markerLocation = block.getLocation().toBlockLocation();
+                        chestLocations.add(markerLocation.clone());
+                        clearMarkerBlock(markerLocation);
                     } else if (scanMinorMarkers && minorMobMarker != null && block.getType() == minorMobMarker) {
-                        Location spawnLocation = block.getLocation().add(0.5, 1.0, 0.5);
-                        minorMobSpawnLocations.add(spawnLocation);
+                        Location markerLocation = block.getLocation();
+                        minorMobSpawnLocations.add(markerLocation.clone());
                     } else if (scanPlayerMarker && block.getType() == Material.GOLD_BLOCK) {
                         Location spawnLocation = block.getLocation().add(0.5, 1.0, 0.5);
                         spawnLocation.setYaw(slotOrigin.getYaw());
@@ -306,6 +312,94 @@ public class BloodChestSession {
             }
         }
         return spawnMarkerFound;
+    }
+
+    private void clearMarkerBlock(Location location) {
+        if (location == null) {
+            return;
+        }
+        Block block = location.getBlock();
+        if (block.getType() == arenaSettings.getChestMarkerMaterial()) {
+            block.setType(Material.AIR, false);
+        }
+    }
+
+    private void openChest(Block block) {
+        if (block == null) {
+            return;
+        }
+        BlockState state = block.getState();
+        boolean opened = false;
+        if (state instanceof Lidded lidded) {
+            lidded.open();
+            opened = true;
+        }
+        if (state instanceof TileState tileState) {
+            tileState.update(true, false);
+        } else if (opened) {
+            state.update(true, false);
+        }
+    }
+
+    private void keepChestOpen(Block block) {
+        if (block == null) {
+            return;
+        }
+        BlockState state = block.getState();
+        if (!(state instanceof Lidded)) {
+            return;
+        }
+        Location key = block.getLocation().toBlockLocation();
+        if (chestOpenTasks.containsKey(key)) {
+            return;
+        }
+        BukkitRunnable runnable = new BukkitRunnable() {
+            @Override
+            public void run() {
+                BukkitTask currentTask = chestOpenTasks.get(key);
+                if (currentTask == null || currentTask.getTaskId() != getTaskId()) {
+                    cancel();
+                    return;
+                }
+                if (finished) {
+                    cancelChestTask(key, getTaskId());
+                    return;
+                }
+                Boolean opened = spawnedChests.get(key);
+                if (opened == null || !opened) {
+                    cancelChestTask(key, getTaskId());
+                    return;
+                }
+                Block chestBlock = key.getBlock();
+                if (!(chestBlock.getState() instanceof Lidded)) {
+                    cancelChestTask(key, getTaskId());
+                    return;
+                }
+                openChest(chestBlock);
+            }
+        };
+        BukkitTask task = runnable.runTaskTimer(plugin, 0L, 40L);
+        chestOpenTasks.put(key, task);
+    }
+
+    private void cancelChestTask(Location key, int taskId) {
+        BukkitTask task = chestOpenTasks.get(key);
+        if (task != null && task.getTaskId() == taskId) {
+            chestOpenTasks.remove(key);
+            task.cancel();
+        }
+    }
+
+    private void stopChestOpenTasks() {
+        if (chestOpenTasks.isEmpty()) {
+            return;
+        }
+        for (BukkitTask task : chestOpenTasks.values()) {
+            if (task != null) {
+                task.cancel();
+            }
+        }
+        chestOpenTasks.clear();
     }
 
     private Location toWorldBlockLocation(SchematicHandler.BlockOffset offset) {
@@ -423,11 +517,16 @@ public class BloodChestSession {
         if (totalCount <= 0) {
             return;
         }
+        Location baseCenter = resolveMinorMobCenter(markerLocation);
         int index = 0;
         for (MinorMobSpawn spawn : groupDefinitions) {
             for (int i = 0; i < spawn.getCount(); i++) {
-                Location spreadLocation = computeSpreadLocation(markerLocation, index, totalCount);
-                spawnMob(world, mobSettings, spreadLocation, spawn.getMythicMobId(), SpawnType.ADDITIONAL);
+                Location spreadLocation = computeSpreadLocation(baseCenter, index, totalCount);
+                Location resolvedSpawn = resolveMinorMobSpawnLocation(spreadLocation);
+                logMinorMobSpawn(spawn.getMythicMobId(), markerLocation, spreadLocation, resolvedSpawn);
+                SpawnAssignment assignment = spawnMob(world, mobSettings, resolvedSpawn, spawn.getMythicMobId(),
+                        SpawnType.ADDITIONAL, false);
+                scheduleMinorSpawnCheck(assignment, spawn.getMythicMobId(), resolvedSpawn);
                 index++;
             }
         }
@@ -452,23 +551,148 @@ public class BloodChestSession {
         return new Location(center.getWorld(), x, center.getY(), z);
     }
 
-    private void spawnMob(World world,
-                          MobSettings mobSettings,
-                          Location spawnLocation,
-                          String mythicId,
-                          SpawnType type) {
-        Location adjustedLocation = applySpawnOffset(spawnLocation, mobSettings);
+    private Location resolveMinorMobCenter(Location markerLocation) {
+        Location base = markerLocation.clone();
+        base.setX(markerLocation.getBlockX() + 0.5);
+        base.setZ(markerLocation.getBlockZ() + 0.5);
+        base.setY(markerLocation.getBlockY() + 1.0);
+        return resolveMinorMobSpawnLocation(base);
+    }
+
+    private Location resolveMinorMobSpawnLocation(Location approximate) {
+        Location candidate = approximate.clone();
+        World world = candidate.getWorld();
+        if (world == null) {
+            return candidate;
+        }
+        int x = (int) Math.floor(candidate.getX());
+        int z = (int) Math.floor(candidate.getZ());
+        int worldMin = world.getMinHeight();
+        int worldMax = world.getMaxHeight();
+        int baseY = Math.max(worldMin + 1, Math.min(worldMax - 1, candidate.getBlockY()));
+        int upwardLimit = Math.min(worldMax - 1, baseY + 6);
+        for (int y = baseY; y <= upwardLimit; y++) {
+            if (isValidMinorMobColumn(world, x, y, z)) {
+                Location resolved = new Location(world, x + 0.5, y, z + 0.5);
+                if (y != baseY) {
+                    plugin.getLogger().info(String.format(Locale.ROOT,
+                            "Adjusted minor mob spawn upwards from %s to %s", formatLocation(candidate),
+                            formatLocation(resolved)));
+                }
+                return resolved;
+            }
+        }
+        int downwardLimit = Math.max(worldMin + 1, baseY - 6);
+        for (int y = baseY - 1; y >= downwardLimit; y--) {
+            if (isValidMinorMobColumn(world, x, y, z)) {
+                Location resolved = new Location(world, x + 0.5, y, z + 0.5);
+                plugin.getLogger().info(String.format(Locale.ROOT,
+                        "Adjusted minor mob spawn downwards from %s to %s", formatLocation(candidate),
+                        formatLocation(resolved)));
+                return resolved;
+            }
+        }
+        Location fallback = new Location(world, x + 0.5, baseY, z + 0.5);
+        plugin.getLogger().warning(String.format(Locale.ROOT,
+                "Falling back to blocked minor mob spawn location %s", formatLocation(fallback)));
+        return fallback;
+    }
+
+    private void logMinorMobSpawn(String mythicId,
+                                  Location markerLocation,
+                                  Location requestedLocation,
+                                  Location resolvedLocation) {
+        String id = mythicId != null ? mythicId : "<unknown>";
+        StringBuilder message = new StringBuilder(String.format(Locale.ROOT,
+                "Spawning minor mob %s at %s (marker %s)",
+                id,
+                formatLocation(resolvedLocation),
+                formatLocation(markerLocation)));
+        if (resolvedLocation.distanceSquared(requestedLocation) > 0.01) {
+            message.append(String.format(Locale.ROOT,
+                    " after adjusting from %s",
+                    formatLocation(requestedLocation)));
+        }
+        plugin.getLogger().info(message.toString());
+    }
+
+    private void scheduleMinorSpawnCheck(SpawnAssignment assignment, String mythicId, Location targetLocation) {
+        if (assignment == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (finished) {
+                return;
+            }
+            if (pendingSpawnAssignments.contains(assignment)) {
+                String id = mythicId != null ? mythicId : "<unknown>";
+                String message = String.format(Locale.ROOT,
+                        "Minor mob %s did not spawn at %s within expected time. Pending assignments: %d",
+                        id,
+                        formatLocation(targetLocation),
+                        pendingSpawnAssignments.size());
+                plugin.getLogger().warning(message);
+            }
+        }, 40L);
+    }
+
+    private String formatLocation(Location location) {
+        if (location == null) {
+            return "<null>";
+        }
+        World world = location.getWorld();
+        String worldName = world != null ? world.getName() : "<world>";
+        return String.format(Locale.ROOT, "%s[%.2f, %.2f, %.2f]",
+                worldName,
+                location.getX(),
+                location.getY(),
+                location.getZ());
+    }
+
+    private boolean isPassable(Block block) {
+        if (block == null) {
+            return true;
+        }
+        Material type = block.getType();
+        return type.isAir() || block.isPassable();
+    }
+
+    private boolean isValidMinorMobColumn(World world, int x, int y, int z) {
+        Block feet = world.getBlockAt(x, y, z);
+        Block head = world.getBlockAt(x, y + 1, z);
+        Block below = world.getBlockAt(x, y - 1, z);
+        return isPassable(feet) && isPassable(head) && !isPassable(below);
+    }
+
+    private SpawnAssignment spawnMob(World world,
+                                     MobSettings mobSettings,
+                                     Location spawnLocation,
+                                     String mythicId,
+                                     SpawnType type) {
+        return spawnMob(world, mobSettings, spawnLocation, mythicId, type, true);
+    }
+
+    private SpawnAssignment spawnMob(World world,
+                                     MobSettings mobSettings,
+                                     Location spawnLocation,
+                                     String mythicId,
+                                     SpawnType type,
+                                     boolean applyOffset) {
+        Location adjustedLocation = applyOffset ? applySpawnOffset(spawnLocation, mobSettings) : spawnLocation.clone();
         if (mobSettings.getSpawnMode() == SpawnMode.MYTHIC_COMMAND) {
             String normalizedId = normalizeMythicName(mythicId);
-            pendingSpawnAssignments.add(new SpawnAssignment(adjustedLocation.clone(), type, normalizedId));
+            SpawnAssignment assignment = new SpawnAssignment(adjustedLocation.clone(), type, normalizedId);
+            pendingSpawnAssignments.add(assignment);
             String command = buildSpawnCommand(mythicId, mobSettings, adjustedLocation);
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            return assignment;
         } else {
             EntityType fallback = mobSettings.getFallbackEntityType();
             Entity entity = world.spawnEntity(adjustedLocation, fallback);
             if (entity instanceof LivingEntity livingEntity) {
                 trackSpawnedEntity(livingEntity, type);
             }
+            return null;
         }
     }
 
@@ -584,14 +808,17 @@ public class BloodChestSession {
         String yaw = formatCoordinate(location.getYaw());
         String pitch = formatCoordinate(location.getPitch());
         String amount = "1";
-        String locationToken = String.join(",", worldName, x, y, z);
         String locationSpaceToken = String.join(" ", worldName, x, y, z);
+        String locationCommaToken = String.join(",", worldName, x, y, z);
         String locationWithAnglesToken = String.join(" ", worldName, x, y, z, yaw, pitch);
         command = LEGACY_LOCATION_PATTERN.matcher(command).replaceAll("{location}");
         return command
                 .replace("{location_with_yaw_pitch}", locationWithAnglesToken)
                 .replace("{location_space}", locationSpaceToken)
-                .replace("{location}", locationToken)
+                .replace("{location_commas}", locationCommaToken)
+                .replace("{location_comma}", locationCommaToken)
+                .replace("{location_csv}", locationCommaToken)
+                .replace("{location}", locationSpaceToken)
                 .replace("{amount}", amount)
                 .replace("{id}", id)
                 .replace("{world}", worldName)
@@ -726,10 +953,12 @@ public class BloodChestSession {
     private void spawnChests(int chestCount) {
         ChestSettings chestSettings = arenaSettings.getChestSettings();
         int available = Math.min(chestCount, chestLocations.size());
+        stopChestOpenTasks();
         spawnedChests.clear();
         for (int i = 0; i < available; i++) {
             Location location = chestLocations.get(i);
-            Block block = location.getBlock();
+            Location blockLocation = location.toBlockLocation();
+            Block block = blockLocation.getBlock();
             block.setType(chestSettings.getChestMaterial(), false);
             if (block.getState() instanceof TileState tileState) {
                 if (tileState instanceof Nameable nameable) {
@@ -739,11 +968,11 @@ public class BloodChestSession {
                         .map(line -> (Component) Component.text(ChatColor.translateAlternateColorCodes('&', line)))
                         .collect(Collectors.toList());
                 if (!lore.isEmpty()) {
-                    chestLoreByLocation.put(location, lore);
+                    chestLoreByLocation.put(blockLocation, lore);
                 }
                 tileState.update();
             }
-            spawnedChests.put(location, Boolean.FALSE);
+            spawnedChests.put(blockLocation, Boolean.FALSE);
         }
         player.sendMessage(color("&c" + available + " Blood Chests have appeared!"));
     }
@@ -752,17 +981,21 @@ public class BloodChestSession {
         if (finished || !clicker.getUniqueId().equals(player.getUniqueId())) {
             return false;
         }
-        Location location = block.getLocation();
+        Location location = block.getLocation().toBlockLocation();
         Boolean opened = spawnedChests.get(location);
-        if (opened == null || opened) {
+        if (opened == null) {
             return false;
+        }
+        if (opened) {
+            return true;
         }
         spawnedChests.put(location, Boolean.TRUE);
         List<Component> lore = chestLoreByLocation.remove(location);
         if (lore != null && !lore.isEmpty()) {
             lore.forEach(player::sendMessage);
         }
-        block.setType(Material.AIR, false);
+        openChest(block);
+        keepChestOpen(block);
         LootResult result = lootService.generateLoot(player.getUniqueId(), rewardSettings.getRollsPerChest(), pityManager);
         dropItems(location, result);
         if (result.isPityGranted()) {
@@ -837,49 +1070,43 @@ public class BloodChestSession {
         if (items.isEmpty()) {
             return;
         }
-        new BukkitRunnable() {
-            int index = 0;
-
-            @Override
-            public void run() {
-                if (index >= items.size()) {
-                    cancel();
-                    return;
-                }
-                org.bukkit.inventory.ItemStack item = items.get(index++);
-                org.bukkit.entity.Item dropped = dropLocation.getWorld().dropItem(dropLocation, item);
-                Vector velocity = new Vector(ThreadLocalRandom.current().nextGaussian() * 0.05,
-                        0.35, ThreadLocalRandom.current().nextGaussian() * 0.05);
-                dropped.setVelocity(velocity);
-            }
-        }.runTaskTimer(plugin, 0L, 10L);
+        World world = dropLocation.getWorld();
+        if (world == null) {
+            return;
+        }
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (org.bukkit.inventory.ItemStack item : items) {
+            org.bukkit.entity.Item dropped = world.dropItem(dropLocation, item);
+            Vector velocity = new Vector(random.nextGaussian() * 0.08,
+                    0.35 + random.nextDouble(0.05),
+                    random.nextGaussian() * 0.08);
+            dropped.setVelocity(velocity);
+        }
     }
 
     private void startExitCountdown() {
         if (exitCountdownTask != null) {
             return;
         }
-        exitCountdownSeconds = rewardSettings.getExitCountdownSeconds();
+        exitCountdownTotalSeconds = Math.max(1, rewardSettings.getExitCountdownSeconds());
+        updateExitCountdownBossBar(exitCountdownTotalSeconds, exitCountdownTotalSeconds);
         exitCountdownTask = new BukkitRunnable() {
-            int remaining = exitCountdownSeconds;
+            int remaining = exitCountdownTotalSeconds;
 
             @Override
             public void run() {
+                remaining--;
                 if (remaining <= 0) {
                     cancel();
                     exitCountdownTask = null;
                     finishSession();
                     return;
                 }
-                Title title = Title.title(Component.text(ChatColor.RED + "Returning in"),
-                        Component.text(ChatColor.GOLD + String.valueOf(remaining) + ChatColor.GRAY + " s"),
-                        Title.Times.times(Duration.ZERO, Duration.ofSeconds(1), Duration.ZERO));
-                player.showTitle(title);
-                remaining--;
+                updateExitCountdownBossBar(remaining, exitCountdownTotalSeconds);
             }
         };
-        exitCountdownTask.runTaskTimer(plugin, 0L, 20L);
-        player.sendMessage(color("&7You will be teleported in &e" + exitCountdownSeconds + "s"));
+        exitCountdownTask.runTaskTimer(plugin, 20L, 20L);
+        player.sendMessage(color("&7You will be teleported in &e" + exitCountdownTotalSeconds + "s"));
     }
 
     private void finishSession() {
@@ -1015,6 +1242,7 @@ public class BloodChestSession {
             exitCountdownTask.cancel();
             exitCountdownTask = null;
         }
+        exitCountdownTotalSeconds = 0;
     }
 
     private void initializeBossBar() {
@@ -1063,6 +1291,28 @@ public class BloodChestSession {
         progressBar.setTitle(color(title));
     }
 
+    private void updateExitCountdownBossBar(int remainingSeconds, int totalSeconds) {
+        if (player == null) {
+            return;
+        }
+        if (progressBar == null) {
+            progressBar = Bukkit.createBossBar(color("&6Blood Chests"), BarColor.YELLOW, BarStyle.SOLID);
+        }
+        if (!player.isOnline()) {
+            return;
+        }
+        if (!progressBar.getPlayers().contains(player)) {
+            progressBar.addPlayer(player);
+        }
+        progressBar.setColor(BarColor.YELLOW);
+        double progress = totalSeconds <= 0 ? 0.0 : Math.max(0.0, Math.min(1.0, remainingSeconds / (double) totalSeconds));
+        progressBar.setProgress(progress);
+        String title = String.format(Locale.ROOT,
+                "&6Blood Chests &7| &aRewards collected &7| &eTeleporting in %ds",
+                Math.max(0, remainingSeconds));
+        progressBar.setTitle(color(title));
+    }
+
     private void showVictoryOnBossBar(long elapsedSeconds, int chestCount) {
         if (progressBar == null) {
             return;
@@ -1071,7 +1321,7 @@ public class BloodChestSession {
         progressBar.setColor(BarColor.GREEN);
         progressBar.setProgress(1.0);
         String title = String.format(Locale.ROOT,
-                "&2Blood Chests &7| &c%d&7/&c%d &7Blood Sludges | &e%ds &7→ &6%d skrzynek",
+                "&2Blood Chests &7| &c%d&7/&c%d &7Blood Sludges | &e%ds &7→ &6%d chests",
                 defeatedPrimaryCount,
                 Math.max(requiredPrimaryCount, defeatedPrimaryCount),
                 Math.max(0L, elapsedSeconds),
@@ -1144,6 +1394,7 @@ public class BloodChestSession {
         finished = true;
         cancelExitCountdown();
         clearBossBar();
+        stopChestOpenTasks();
         removeTrackedMobs();
         boolean canTeleportNow = teleportNow && player.isOnline() && !player.isDead();
         if (!teleportOnRespawn && canTeleportNow) {

--- a/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/util/ItemStackUtil.java
@@ -2,13 +2,18 @@ package pl.yourserver.bloodChestPlugin.util;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextDecoration.State;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import pl.yourserver.bloodChestPlugin.loot.LootItemDefinition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public final class ItemStackUtil {
 
@@ -47,6 +52,19 @@ public final class ItemStackUtil {
                 }
                 meta.lore(loreComponents);
             }
+            Map<Enchantment, Integer> enchantments = definition.getEnchantments();
+            for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
+                meta.addEnchant(entry.getKey(), entry.getValue(), true);
+            }
+            if (definition.isUnbreakable()) {
+                meta.setUnbreakable(true);
+            }
+            if (definition.isHideFlags()) {
+                meta.addItemFlags(ItemFlag.values());
+            }
+            if (definition.isHideAttributes()) {
+                meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+            }
             stack.setItemMeta(meta);
         }
         return stack;
@@ -56,6 +74,7 @@ public final class ItemStackUtil {
         if (input == null) {
             return Component.empty();
         }
-        return SERIALIZER.deserialize(input.replace("§", "&"));
+        Component component = SERIALIZER.deserialize(input.replace("§", "&"));
+        return component.decorationIfAbsent(TextDecoration.ITALIC, State.FALSE);
     }
 }


### PR DESCRIPTION
## Summary
- load item options and enchantments from items.yml into loot definitions and apply hide flags, unbreakable state, and enchants when creating reward drops
- normalize chest marker handling so schematic placeholders are cleared, chests stay visible and open after looting, and lid tasks stop when the arena resets
- adjust Mythic spawn command formatting to use space-separated coordinates so minor mobs spawn reliably on DIRT markers

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbf5930b0c832ab2cf9fdd0b5a8850