### PR TITLE
Ensure blood chest sessions return players to spawn

### DIFF
--- a/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
+++ b/src/main/java/pl/yourserver/bloodChestPlugin/session/SessionManager.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 
 public class SessionManager {
 
@@ -149,6 +150,24 @@ public class SessionManager {
 
     public void clearPendingReturn(UUID playerId) {
         pendingReturns.remove(playerId);
+    }
+
+    public boolean dispatchSpawnCommand(Player player) {
+        if (player == null) {
+            return false;
+        }
+        String command = "spawn " + player.getName();
+        try {
+            boolean success = Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            if (!success) {
+                plugin.getLogger().warning("[BloodChest] Failed to execute /" + command + " for player " + player.getName());
+            }
+            return success;
+        } catch (Exception ex) {
+            plugin.getLogger().log(Level.WARNING,
+                    "[BloodChest] Error executing /" + command + ": " + ex.getMessage(), ex);
+            return false;
+        }
     }
 
     public void shutdown() {


### PR DESCRIPTION
## Summary
- run the EssentialsX `/spawn` command for players when a blood chest session ends, with a direct teleport fallback
- dispatch the same command after respawn so deaths also return players to spawn reliably
- allow minor mobs spawned from DIRT markers to receive the configured spawn offset so they appear like the primary mob

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dc105dab14832a9d7199cccfd83cce